### PR TITLE
add pagination to initial dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ The following environment variables can be provided:
 - `LDES_CATCH_UP_PAGE_SIZE`: the page size used when catching up. Only used when `LDES_STATUS_GRAPH` is set
 - `LDES_CATCH_UP_INITIAL_OFFSET`: the offset in ms used when catching up after restart. Only used when `LDES_STATUS_GRAPH` is set. Defaults to 1. Upon restart, the pusher will add all items on the LDES with a dct:modified >= the last sync date - the offset. This might add a little duplicate info on the LDES but this way, if two items had the same dct:modified and only the first one made it onto the LDES, now the second one is also there.
 
-- `WRITE_INITIAL_STATE`: if set to "true", this writes the current state of the database to the ldes stream as one large page. Default: "false"
-- `INITIAL_STATE_FILE_PATH`: the path of where to write the initial state (appended as ttl to the existing file). The file that is written to is `/data/${streamname}/${INITIAL_STATE_FILE_PATH}` and must exist up front (with the stream's meta info in it). Default: 2.ttl
-- `INITIAL_STATE_LIMIT`: the limit to use when writing batches to the initial state file. Note: every batch will have its own prefixes, which means prefixes are redefined (allowed by the turtle spec and virtuoso). Default: 10000
-- `DIRECT_DB_ENDPOINT`: writing the initial state requires a direct connection to the database (we use ttl directly). This is the url of the database. Default: http://virtuoso:8890/sparql
+- `WRITE_INITIAL_STATE`: if set to "true", this writes the current state of the database to the ldes stream as one large page. Default: "false". Writes to `/data/${streamname}/${firstfilebynumericalsort}.ttl` or creates file `1.ttl` if no file exists. Streams are configured in `config/initialization.ts`
+- `LDES_BASE`: base url to be used for the LDES stream that is published. Defaults to `http://lmb.lblod.info/streams/ldes`, only used if `WRITE_INITIAL_STATE` is true.
+- `MAX_PAGE_SIZE_BYTES`: the maximum size of every initial LDES page file in bytes, defaults to `10000000`. Only used if `WRITE_INITIAL_STATE` is true.
+- `INITIAL_STATE_LIMIT`: the limit to use when writing batches to the initial state file. Note: every batch will have its own prefixes, which means prefixes are redefined (allowed by the turtle spec and virtuoso). Default: 10000. Only used if `WRITE_INITIAL_STATE` is true.
+- `DIRECT_DB_ENDPOINT`: writing the initial state requires a direct connection to the database (we use ttl directly). This is the url of the database. Default: http://virtuoso:8890/sparql. Only used if `WRITE_INITIAL_STATE` is true.
 
 > [!CAUTION]
 > The catching up after restart process is EXPERIMENTAL. It also has the drawback that IF you add a migration (not triggering deltas right now) with concepts that have modified dates earlier than the moment the LDES has caught up to, these instances will NOT be detected by the catch up process and will NOT appear on the LDES feed. You can get around that by setting the ext:lastSync for the LDES pusher to before these modified dates, but that will trigger some duplication on the feed.

--- a/config/initialization.ts
+++ b/config/initialization.ts
@@ -2,10 +2,9 @@ const regularTypes = {
   "http://data.vlaanderen.be/ns/mandaat#Fractie": "public",
   "http://www.w3.org/ns/org#Membership": "public",
   "http://data.vlaanderen.be/ns/mandaat#Mandaat": "public",
-  "http://www.w3.org/ns/person#Person": "public",
   "http://purl.org/dc/terms/PeriodOfTime": "public",
   "http://www.w3.org/ns/adms#Identifier": "abb",
-  "http://data.vlaanderen.be/ns/persoon#Geboorte": "public",
+  "http://data.vlaanderen.be/ns/persoon#Geboorte": "abb",
   "http://schema.org/ContactPoint": "abb",
   "http://www.w3.org/ns/locn#Address": "abb",
 };
@@ -17,13 +16,19 @@ export const initialization = {
         OPTIONAL { ?s <http://mu.semte.ch/vocabularies/ext/lmb/hasPublicationStatus> ?publicationStatus. }
         FILTER(!BOUND(?publicationStatus) || ?publicationStatus != <http://data.lblod.info/id/concept/MandatarisPublicationStatusCode/588ce330-4abb-4448-9776-a17d9305df07>)`,
     },
+    "http://www.w3.org/ns/person#Person": {
+      filter: `FILTER(?p NOT IN (<http://data.vlaanderen.be/ns/persoon#heeftGeboorte>, <http://www.w3.org/ns/adms#identifier>, <http://data.vlaanderen.be/ns/persoon#geslacht>))
+      `,
+    },
   },
   abb: {
     // meaning there is no filter
     "http://data.vlaanderen.be/ns/mandaat#Mandataris": {},
+    "http://www.w3.org/ns/person#Person": {},
   },
   internal: {
     "http://data.vlaanderen.be/ns/mandaat#Mandataris": {},
+    "http://www.w3.org/ns/person#Person": {},
   },
 };
 


### PR DESCRIPTION
This adds pagination to the initial dump script. See the readme and the config in the linked PR to see how to use this.

https://github.com/lblod/app-lokaal-mandatenbeheer/pull/195