### PR TITLE
fix too many tombstones being recreated

### DIFF
--- a/config/healing.ts
+++ b/config/healing.ts
@@ -49,9 +49,10 @@ export const getHealingConfig = async () => {
         "http://purl.org/dc/terms/PeriodOfTime": [
           "http://purl.org/dc/terms/modified",
         ],
-        "http://www.w3.org/ns/activitystreams#Tombstone": [
-          "http://purl.org/dc/terms/modified",
-        ],
+        "http://www.w3.org/ns/activitystreams#Tombstone": {
+          healingPredicates: ["http://purl.org/dc/terms/modified"],
+          healingFilter: "",
+        },
       },
       graphsToExclude: ["http://mu.semte.ch/graphs/besluiten-consumed"],
       graphTypesToExclude: ["http://mu.semte.ch/vocabularies/ext/FormHistory"],

--- a/config/healing.ts
+++ b/config/healing.ts
@@ -51,7 +51,14 @@ export const getHealingConfig = async () => {
         ],
         "http://www.w3.org/ns/activitystreams#Tombstone": {
           healingPredicates: ["http://purl.org/dc/terms/modified"],
-          healingFilter: "",
+          // an example filter that only erects tombstones if they don't have any other type in any other graph owned by an org
+          healingFilter: `FILTER NOT EXISTS {
+            GRAPH ?h {
+             ?s a ?otherType.
+             FILTER(?otherType != <http://www.w3.org/ns/activitystreams#Tombstone>)
+            }
+            ?h <http://mu.semte.ch/vocabularies/ext/ownedBy> ?org.
+          }`,
         },
       },
       graphsToExclude: ["http://mu.semte.ch/graphs/besluiten-consumed"],


### PR DESCRIPTION
- fixes tombstones forever being recreated because their type was changed to tombstone in the db so it's logical that they are not immediately in the db after being fixed. Then they got a different modified and the cycle kept going because there was a difference in modified date
-  also allow for an extra filter on the items created when healing so that if a tombstone exists for something in one graph but not in another, the tombstone is not added to the ldes