### PR TITLE
improve efficiency of duplicate checking

### DIFF
--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -69,6 +69,7 @@ async function loadStreamIntoDumpGraph(stream: string): Promise<void> {
     }
     currentPage = await determineNextPage(stream, currentPage);
   }
+  await deleteDuplicatesForValues();
 }
 
 async function fetchPage(stream: string, page: number): Promise<string | null> {


### PR DESCRIPTION
the query for duplicate checking is pretty heavy on virtuoso but it's much more efficient to just do it fewer times for larger sets of values.