### PR TITLE
prep for old virtuoso and new js modules

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -8,7 +8,7 @@ import { Changeset } from "./types";
 import { writeInitialState } from "./writeInitialState";
 
 import { cronjob as autoHealing } from "./self-healing/cron";
-import { AUTO_HEALING, CRON_CHECKPOINT, LDES_BASE } from "./config";
+import { AUTO_HEALING, LDES_BASE } from "./environment";
 import { ttlFileAsContentType } from "./util/ttlFileAsContentType";
 import { cronjob as checkpointCron } from "./writeInitialState";
 

--- a/environment.ts
+++ b/environment.ts
@@ -2,11 +2,11 @@ export const LDES_FRAGMENTER = process.env.LDES_FRAGMENTER as
   | string
   | undefined;
 export const LDES_FOLDER = process.env.LDES_FOLDER as string;
-export const DATA_FOLDER = process.env.DATA_FOLDER || "/data" as string;
+export const DATA_FOLDER = process.env.DATA_FOLDER || ("/data" as string);
 export const AUTO_HEALING = process.env.AUTO_HEALING ?? false;
 export const CRON_HEALING = process.env.CRON_HEALING ?? "0 * * * *"; // Every hour
 export const CRON_CHECKPOINT = process.env.CRON_CHECKPOINT;
-export const HEALING_LIMIT = process.env.HEALING_LIMIT || 1000;
+export const HEALING_LIMIT = process.env.HEALING_LIMIT || 3000;
 export const HEALING_BATCH_SIZE = parseInt(
   process.env.HEALING_BATCH_SIZE ?? "100"
 );
@@ -33,9 +33,10 @@ export const LDES_BASE = ldesBase;
 process.env.BASE_URL = LDES_BASE; // required by the ldes-producer
 
 if (!LDES_FOLDER?.length) {
-  throw new Error('Please set the "LDES_FOLDER" environment variable. e.g: ldes-mow-registry');
+  throw new Error(
+    'Please set the "LDES_FOLDER" environment variable. e.g: ldes-mow-registry'
+  );
 }
-
 
 console.log("\n Configuration:");
 console.log(`\t AUTO_HEALING: ${AUTO_HEALING}`);

--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -8,7 +8,7 @@ import {
   deleteDuplicatesForValues,
 } from "./upload-entities-to-db";
 import { transformLdesDataToEntities } from "./transform-ldes-data-to-entities";
-import { CRON_HEALING } from "../config";
+import { CRON_HEALING } from "../environment";
 import { HealingConfig, getHealingConfig } from "../config/healing";
 import { ttlFileAsString } from "../util/ttlFileAsContentType";
 

--- a/self-healing/heal-ldes-data.ts
+++ b/self-healing/heal-ldes-data.ts
@@ -6,7 +6,7 @@ import {
   HEALING_TRANSFORMED_GRAPH,
   DIRECT_DB_ENDPOINT,
   HEALING_LIMIT,
-} from "../config";
+} from "../environment";
 import { HealingConfig } from "../config/healing";
 
 export async function healEntities(

--- a/self-healing/transform-ldes-data-to-entities.ts
+++ b/self-healing/transform-ldes-data-to-entities.ts
@@ -1,8 +1,8 @@
 import { querySudo, updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 
-import { HEALING_DUMP_GRAPH, HEALING_TRANSFORMED_GRAPH } from "../config";
-import { DIRECT_DB_ENDPOINT } from "../config";
+import { HEALING_DUMP_GRAPH, HEALING_TRANSFORMED_GRAPH } from "../environment";
+import { DIRECT_DB_ENDPOINT } from "../environment";
 
 export async function transformLdesDataToEntities() {
   await transformRemainingEntities();

--- a/self-healing/upload-entities-to-db.ts
+++ b/self-healing/upload-entities-to-db.ts
@@ -7,8 +7,8 @@ import {
   HEALING_BATCH_SIZE,
   HEALING_DUMP_GRAPH,
   HEALING_TRANSFORMED_GRAPH,
-} from "../config";
-import { DIRECT_DB_ENDPOINT } from "../config";
+} from "../environment";
+import { DIRECT_DB_ENDPOINT } from "../environment";
 
 export async function clearHealingTempGraphs(): Promise<void> {
   await updateSudo(

--- a/support.ts
+++ b/support.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { sparqlEscapeUri, sparqlEscape } from "mu";
-import { LDES_FOLDER, LDES_FRAGMENTER, } from "./config";
+import { LDES_FOLDER, LDES_FRAGMENTER } from "./environment";
 import { Changeset, Quad, Term } from "./types";
 import { addData, getConfigFromEnv } from "@lblod/ldes-producer";
 
@@ -8,57 +8,55 @@ const ldesProducerConfig = getConfigFromEnv();
 console.log("ldesProducerConfig", ldesProducerConfig);
 
 const datatypeNames = {
-	"http://www.w3.org/2001/XMLSchema#dateTime": "dateTime",
-	"http://www.w3.org/2001/XMLSchema#date": "date",
-	"http://www.w3.org/2001/XMLSchema#decimal": "decimal",
-	"http://www.w3.org/2001/XMLSchema#integer": "int",
-	"http://www.w3.org/2001/XMLSchema#float": "float",
-	"http://www.w3.org/2001/XMLSchema#boolean": "bool",
+  "http://www.w3.org/2001/XMLSchema#dateTime": "dateTime",
+  "http://www.w3.org/2001/XMLSchema#date": "date",
+  "http://www.w3.org/2001/XMLSchema#decimal": "decimal",
+  "http://www.w3.org/2001/XMLSchema#integer": "int",
+  "http://www.w3.org/2001/XMLSchema#float": "float",
+  "http://www.w3.org/2001/XMLSchema#boolean": "bool",
 };
 const sparqlEscapeObject = (bindingObject: Term): string => {
-	const escapeType = datatypeNames[bindingObject?.datatype || ""] || "string";
-	if (
-		bindingObject.datatype === "http://www.w3.org/2001/XMLSchema#dateTime"
-	) {
-		// sparqlEscape formats it slightly differently and then the comparison breaks in healing
-		const safeValue = `${bindingObject.value}`;
-		return `"${safeValue.split("\"").join("")}"^^xsd:dateTime`;
-	}
-	return bindingObject.type === "uri"
-		? sparqlEscapeUri(bindingObject.value)
-		: sparqlEscape(bindingObject.value, escapeType);
+  const escapeType = datatypeNames[bindingObject?.datatype || ""] || "string";
+  if (bindingObject.datatype === "http://www.w3.org/2001/XMLSchema#dateTime") {
+    // sparqlEscape formats it slightly differently and then the comparison breaks in healing
+    const safeValue = `${bindingObject.value}`;
+    return `"${safeValue.split('"').join("")}"^^xsd:dateTime`;
+  }
+  return bindingObject.type === "uri"
+    ? sparqlEscapeUri(bindingObject.value)
+    : sparqlEscape(bindingObject.value, escapeType);
 };
 
-
 export function toSparqlTriple(quad: Quad): string {
-	return `${sparqlEscapeObject(quad.subject)} ${sparqlEscapeObject(quad.predicate)} ${sparqlEscapeObject(quad.object)}.`;
+  return `${sparqlEscapeObject(quad.subject)} ${sparqlEscapeObject(
+    quad.predicate
+  )} ${sparqlEscapeObject(quad.object)}.`;
 }
 
-export async function moveTriples(changesets: Changeset[], stream = LDES_FOLDER) {
-	let turtleBody = "";
-	for (const { inserts } of changesets) {
-		if (inserts.length) {
-			inserts.forEach((triple) => {
-				turtleBody += toSparqlTriple(triple);
-			});
+export async function moveTriples(
+  changesets: Changeset[],
+  stream = LDES_FOLDER
+) {
+  let turtleBody = "";
+  for (const { inserts } of changesets) {
+    if (inserts.length) {
+      inserts.forEach((triple) => {
+        turtleBody += toSparqlTriple(triple);
+      });
+    }
+  }
+  if (!turtleBody.length) {
+    console.log("nothing to do.");
+    return;
+  }
 
-		}
-	}
-	if (!turtleBody.length) {
-		console.log('nothing to do.');
-		return;
-	}
+  turtleBody =
+    "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n" + turtleBody;
 
-	turtleBody = "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n" + turtleBody;
-
-	await addData(ldesProducerConfig, {
-		contentType: "text/turtle",
-		folder: stream,
-		body: turtleBody,
-		fragmenter: LDES_FRAGMENTER
-	});
-
-
+  await addData(ldesProducerConfig, {
+    contentType: "text/turtle",
+    folder: stream,
+    body: turtleBody,
+    fragmenter: LDES_FRAGMENTER,
+  });
 }
-
-

--- a/util/ttlFileAsContentType.ts
+++ b/util/ttlFileAsContentType.ts
@@ -1,5 +1,4 @@
-const ttl_read = require("@graphy/content.ttl.read");
-
+import ttl_read from "@graphy/content.ttl.read";
 import fs from "fs";
 import path from "path";
 import jsstream from "stream";

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -97,7 +97,7 @@ async function cleanupVersionedUris() {
 
 async function executeDirectQuery(
   query: string,
-  ttlClient: SparqlClient,
+  ttlClient: typeof SparqlClient,
   retries = 5
 ) {
   try {


### PR DESCRIPTION
renamed config to environment so js is not confused about the config folder and tries to look for an index.ts there
reworked a couple of incorrect imports that would give issues when we allow ES modules
added a workaround for broken uuids in old virtuoso versions, see https://github.com/openlink/virtuoso-opensource/issues/515#issuecomment-456848368