### PR TITLE
Add manual trigger for healing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The LDES delta pusher can fetch its own stream(s) and compare the final result w
 
 The stream is read directly from the backend service (using the internal docker compose network) and stored into a temporary graph in the database. The default implementation only looks at the dct:modified time of the instances. The assumption here is that if the modified time is the same, then all other data will also be up to date on the stream. However, by adding other predicates to the `healingPredicates` array in the config, you can have the stream also check for values of other predicates that are not on the LDES stream. Have a look at the example config in `config/healing.ts`, it clarifies the meaning of each value
 
+## Manual trigger of the healing process
+
+The `/manual-healing` endpoint allows for manually triggering the healing process by sending a `POST` request.
+To reach the service with `curl`, you will have to expose its ports in the compose config, and curl from the system the stack is running on.
+
+Of course, you can also use the dispatcher for a more robust way, but the need for manually triggering the healing should be rather exceptional.
+
+Note also the process can take quite a long time depending on the size of your database. The endpoint is currently not taskified and will block the request for as long as it's running.
+
+
 ## Checkpoints
 
 Once your LDES has been producing for a while, it can be annoying for clients to have to fetch all changes since the beginning of the stream. They may only be interested in the changes in the last month for instance. Or they may just want to be in sync with the current state of the stream.

--- a/app.ts
+++ b/app.ts
@@ -7,7 +7,7 @@ import dispatch from "./config/dispatch";
 import { Changeset } from "./types";
 import { writeInitialState } from "./writeInitialState";
 
-import { cronjob as autoHealing } from "./self-healing/cron";
+import { cronjob as autoHealing, manualTrigger } from "./self-healing/cron";
 import { AUTO_HEALING, DATA_FOLDER, LDES_BASE } from "./environment";
 import { ttlFileAsContentType } from "./util/ttlFileAsContentType";
 import { cronjob as checkpointCron } from "./writeInitialState";
@@ -61,6 +61,20 @@ app.get("/checkpoints/:stream", async function (req: Request, res: Response) {
     res.status(500).send();
   }
 });
+/**
+* A manual trigger of the auto-healing process. Runs even if the AUTO_HEALING
+* variable is false, for one-off occasions.
+*/
+app.post("/manual-healing", async function(_req: Request, res: Response) {
+  try {
+    await manualTrigger();
+  } catch(e) {
+    console.error(e)
+    res.status(500).send()
+  }
+  res.status(200)
+  .send(`Healing succesfully completed at ${new Date().toISOString()}`);
+})
 
 new Promise(async (resolve) => {
   if (process.env.WRITE_INITIAL_STATE === "true") {

--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -17,16 +17,8 @@ const ldesProducerConfig = getConfigFromEnv();
 type PagePointer = { path: string; file: number };
 
 let isRunning = false;
-const cronMethod = async () => {
-  console.log(
-    "*******************************************************************"
-  );
-  console.log(
-    `*** Pull LDES triggered by cron job at ${new Date().toISOString()} ***`
-  );
-  console.log(
-    "*******************************************************************"
-  );
+const triggerHealing = async (startMessage: string) => {
+  console.log(startMessage);
 
   if (isRunning) {
     return;
@@ -40,6 +32,14 @@ const cronMethod = async () => {
   }
   isRunning = false;
 };
+const cronMethod = async () =>  triggerHealing(`
+    *******************************************************************
+    *** Pull LDES triggered by cron job at ${new Date().toISOString()} ***
+    *******************************************************************`)
+export const manualTrigger = async () =>  triggerHealing(`
+    *******************************************************************
+    *** Pull LDES triggered by manual trigger at ${new Date().toISOString()} ***
+    *******************************************************************`)
 
 async function healStream(stream: string, config: HealingConfig) {
   const startTime = performance.now();


### PR DESCRIPTION
In some cases, for example after manually changing data in the database, you might want to immediately trigger the self-healing without waiting for the CRON. This could already be achieved by temporarily changing the cron pattern, but that's rather clumsy.

This PR adds a `POST /manual-healing` endpoint which triggers the same logic as the cron job (including the lock to make sure no 2 jobs are running at the same time).

#### uncertainties

I didn't taskify the endpoint, cause tasks are painful to work with and I don't really want to add _another_ ad-hoc implementation of them in a service...
From my testing, curl patiently waits, but with super-long running healing jobs this might be an issue.