### PR TITLE
Limit the initial state construct in the correct way

### DIFF
--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -273,7 +273,7 @@ async function writeInitialStateForStreamAndType(
         { SELECT DISTINCT ?s ?versionedS WHERE {
           ?s a ${sparqlEscapeUri(type)}.
           GRAPH <http://mu.semte.ch/graphs/ldes-initializer> { ?s ext:versionedUri ?versionedS . }
-        } ORDER BY ?s OFFSET ${offset} LIMIT ${limit}  }
+        } ORDER BY ?s }
 
         GRAPH ?g {
           ?s ?p ?o .
@@ -284,7 +284,7 @@ async function writeInitialStateForStreamAndType(
         ${graphFilter}
 
         ${extraWhere}
-      }`;
+      } OFFSET ${offset} LIMIT ${limit}`;
     console.log(query);
     const res = await executeDirectQuery(query, ttlClient);
 


### PR DESCRIPTION
When a construct query isn't limited at the top level, it can return more results than the ResultsetMaxRows setting, which errors.

You'd think then simply adding the extra top-level limit would solve it, keeping the limit on the inner select. 
But of course, virtuoso enriches our lives by making it so that the top-level limit is ignored when there's a limit on an inner select, or at least it does so in this case.

Luckily it seems there is no performance hit for the unconstrained inner select, I think the top-level limit basically has the same effect on the inner query, but I really don't know for sure.