### PR TITLE
Adjust how environment variables are parsed

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -8,7 +8,7 @@ import { Changeset } from "./types";
 import { writeInitialState } from "./writeInitialState";
 
 import { cronjob as autoHealing, manualTrigger } from "./self-healing/cron";
-import { AUTO_HEALING, DATA_FOLDER, LDES_BASE } from "./environment";
+import ENV from "./environment";
 import { ttlFileAsContentType } from "./util/ttlFileAsContentType";
 import { cronjob as checkpointCron } from "./writeInitialState";
 
@@ -52,9 +52,9 @@ app.get("/checkpoints/:stream", async function (req: Request, res: Response) {
     const stream = req.params.stream;
     res.header("Content-Type", contentType);
     ttlFileAsContentType(
-      `${DATA_FOLDER}/${stream}/checkpoints.ttl`,
+      `${ENV.DATA_FOLDER}/${stream}/checkpoints.ttl`,
       contentType,
-      LDES_BASE
+      ENV.LDES_BASE
     ).pipe(res);
   } catch (e) {
     console.error(e);
@@ -81,7 +81,7 @@ new Promise(async (resolve) => {
     await writeInitialState();
   }
 
-  if (AUTO_HEALING == "true") {
+  if (ENV.AUTO_HEALING) {
     autoHealing.start();
   }
   if (checkpointCron) {

--- a/environment.ts
+++ b/environment.ts
@@ -1,51 +1,24 @@
-export const LDES_FRAGMENTER = process.env.LDES_FRAGMENTER as
-  | string
-  | undefined;
-export const LDES_FOLDER = process.env.LDES_FOLDER as string;
-export const DATA_FOLDER = process.env.DATA_FOLDER || ("/data" as string);
-export const AUTO_HEALING = process.env.AUTO_HEALING ?? false;
-export const CRON_HEALING = process.env.CRON_HEALING ?? "0 * * * *"; // Every hour
-export const CRON_CHECKPOINT = process.env.CRON_CHECKPOINT;
-export const HEALING_LIMIT = process.env.HEALING_LIMIT || 3000;
-export const HEALING_BATCH_SIZE = parseInt(
-  process.env.HEALING_BATCH_SIZE ?? "100"
-);
-export const HEALING_DUMP_GRAPH =
-  process.env.HEALING_DUMP_GRAPH ?? "http://mu.semte.ch/graphs/ldes-dump";
-export const HEALING_TRANSFORMED_GRAPH =
-  process.env.HEALING_TRANSFORMED_GRAPH ??
-  "http://mu.semte.ch/graphs/transformed-ldes-data";
-export const DIRECT_DB_ENDPOINT =
-  process.env.DIRECT_DB_ENDPOINT || "http://virtuoso:8890/sparql";
+import * as z from "zod";
 
-let ldesBase = process.env.LDES_BASE || "";
+const EnvSchema = z.object({
+  LDES_FRAGMENTER: z.string().optional(),
+  LDES_FOLDER: z.string(),
+  DATA_FOLDER: z.string().default('/data'),
+  AUTO_HEALING: z.stringbool().default(false),
+  CRON_HEALING: z.string().default('0 * * * *' /* Every hour */),
+  CRON_CHECKPOINT: z.string().optional(),
+  HEALING_LIMIT: z.coerce.number().default(3000),
+  HEALING_BATCH_SIZE: z.coerce.number().default(100),
+  HEALING_DUMP_GRAPH: z.string().default("http://mu.semte.ch/graphs/ldes-dump"),
+  HEALING_TRANSFORMED_GRAPH: z.string().default("http://mu.semte.ch/graphs/transformed-ldes-data"),
+  DIRECT_DB_ENDPOINT: z.string().default("http://virtuoso:8890/sparql"),
+  LDES_BASE: z.string().transform((base) => !base.endsWith('/') ? base + "/" : base),
+})
 
-if (ldesBase === "") {
-  throw new Error('Please set the "LDES_BASE" environment variable');
-}
+const ENV = EnvSchema.parse(process.env);
+process.env.BASE_URL = ENV.LDES_BASE; // required by the ldes-producer
 
-if (!ldesBase.endsWith("/")) {
-  ldesBase += "/";
-}
+console.log("\n Configuration: ")
+console.log(`\n ${ENV}`);
 
-export const LDES_BASE = ldesBase;
-
-process.env.BASE_URL = LDES_BASE; // required by the ldes-producer
-
-if (!LDES_FOLDER?.length) {
-  throw new Error(
-    'Please set the "LDES_FOLDER" environment variable. e.g: ldes-mow-registry'
-  );
-}
-
-console.log("\n Configuration:");
-console.log(`\t AUTO_HEALING: ${AUTO_HEALING}`);
-console.log(`\t CRON_HEALING: ${CRON_HEALING}`);
-console.log(`\t LDES_BASE: ${LDES_BASE}`);
-console.log(`\t LDES_FOLDER: ${LDES_FOLDER}`);
-console.log(`\t DATA_FOLDER: ${DATA_FOLDER}`);
-console.log(`\t DIRECT_DB_ENDPOINT: ${DIRECT_DB_ENDPOINT}`);
-console.log(`\t HEALING_LIMIT: ${HEALING_LIMIT}`);
-console.log(`\t HEALING_DUMP_GRAPH: ${HEALING_DUMP_GRAPH}`);
-console.log(`\t HEALING_TRANSFORMED_GRAPH: ${HEALING_TRANSFORMED_GRAPH}`);
-console.log(`\t HEALING_BATCH_SIZE: ${HEALING_BATCH_SIZE}`);
+export default ENV;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "@types/express": "^4.17.17",
         "@types/node": "^17.0.31",
         "@types/node-fetch": "^2.6.2",
-        "release-it": "^15.6.0"
+        "release-it": "^15.6.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9886,6 +9887,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,18 +4,18 @@
     "url": "git+https://github.com/redpencilio/ldes-delta-pusher-service"
   },
   "dependencies": {
-    "@lblod/ldes-producer": "0.9.0",
-    "@lblod/mu-auth-sudo": "^0.6.2",
     "@graphy/content.ttl.read": "^4.3.4",
     "@graphy/content.ttl.write": "^4.3.4",
+    "@lblod/ldes-producer": "0.9.0",
+    "@lblod/mu-auth-sudo": "^0.6.2",
     "body-parser": "^1.20.0",
     "cron": "^3.1.7",
     "express-http-context": "~1.2.4",
     "forking-store": "^2.2.0",
     "node-fetch": "^2.6.7",
-    "rdflib": "^2.2.35",
     "rdf-parse": "^2.0.0",
     "rdf-serialize": "^2.0.0",
+    "rdflib": "^2.2.35",
     "sparql-client-2": "https://github.com/erikap/node-sparql-client.git"
   },
   "scripts": {
@@ -26,7 +26,8 @@
     "@types/express": "^4.17.17",
     "@types/node": "^17.0.31",
     "@types/node-fetch": "^2.6.2",
-    "release-it": "^15.6.0"
+    "release-it": "^15.6.0",
+    "zod": "^4.3.6"
   },
   "release-it": {
     "github": {

--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -8,7 +8,7 @@ import {
   deleteDuplicatesForValues,
 } from "./upload-entities-to-db";
 import { transformLdesDataToEntities } from "./transform-ldes-data-to-entities";
-import { CRON_HEALING, DATA_FOLDER } from "../environment";
+import ENV from "../environment";
 import { HealingConfig, getHealingConfig } from "../config/healing";
 import { ttlFileAsString } from "../util/ttlFileAsContentType";
 
@@ -99,7 +99,7 @@ async function determineFirstPageOrCheckpoint(
   try {
     console.log(`Fetching checkpoints for stream ${stream}`);
     const fileString = await ttlFileAsString(
-      `${DATA_FOLDER}/${stream}/checkpoints.ttl`,
+      `${ENV.DATA_FOLDER}/${stream}/checkpoints.ttl`,
       "application/ld+json"
     );
     const modified = "http://purl.org/dc/terms/modified";
@@ -159,6 +159,6 @@ async function determineNextPage(
 }
 
 export const cronjob = CronJob.from({
-  cronTime: CRON_HEALING,
+  cronTime: ENV.CRON_HEALING,
   onTick: cronMethod,
 });

--- a/self-healing/heal-ldes-data.ts
+++ b/self-healing/heal-ldes-data.ts
@@ -1,12 +1,7 @@
 import { querySudo, updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri, sparqlEscapeDateTime } from "mu";
 import dispatch from "../config/dispatch";
-import {
-  HEALING_DUMP_GRAPH,
-  HEALING_TRANSFORMED_GRAPH,
-  DIRECT_DB_ENDPOINT,
-  HEALING_LIMIT,
-} from "../environment";
+import ENV from "../environment";
 import { HealingConfig } from "../config/healing";
 
 export async function healEntities(
@@ -124,8 +119,8 @@ async function getDifferences(
   const filter = config[stream].entities[type].instanceFilter || "";
 
   const excludedGraphs = config[stream].graphsToExclude || [];
-  excludedGraphs.push(HEALING_DUMP_GRAPH);
-  excludedGraphs.push(HEALING_TRANSFORMED_GRAPH);
+  excludedGraphs.push(ENV.HEALING_DUMP_GRAPH);
+  excludedGraphs.push(ENV.HEALING_TRANSFORMED_GRAPH);
   const graphFilter = config[stream].graphFilter || "";
   const excludeGraphs = excludedGraphs
     .map((graph: string) => sparqlEscapeUri(graph))
@@ -200,12 +195,12 @@ async function getMissingValuesLdes(options: {
       ${graphFilter}
 
       FILTER NOT EXISTS {
-        GRAPH ${sparqlEscapeUri(HEALING_TRANSFORMED_GRAPH)} {
+        GRAPH ${sparqlEscapeUri(ENV.HEALING_TRANSFORMED_GRAPH)} {
           ?s ?p ?o.
         }
       }
       ${healingFilter}
-    } LIMIT ${HEALING_LIMIT}
+    } LIMIT ${ENV.HEALING_LIMIT}
   `;
 
   if (process.env.VIRTUOSO_DATE_WORKAROUND === "true") {
@@ -223,20 +218,20 @@ async function getMissingValuesLdes(options: {
       ${graphFilter}
 
       FILTER NOT EXISTS {
-        GRAPH ${sparqlEscapeUri(HEALING_TRANSFORMED_GRAPH)} {
+        GRAPH ${sparqlEscapeUri(ENV.HEALING_TRANSFORMED_GRAPH)} {
           ?s ?p ?o2.
           FILTER(STR(?o) = STR(?o2))
         }
       }
       ${healingFilter}
-    } LIMIT ${HEALING_LIMIT}
+    } LIMIT ${ENV.HEALING_LIMIT}
   `;
   }
 
   const result = await querySudo(
     healingQuery,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
   return result.results.bindings.map((binding) => binding);
 }
@@ -267,7 +262,7 @@ async function erectMissingTombstones(
   }
 
   const where = `
-      GRAPH ${sparqlEscapeUri(HEALING_TRANSFORMED_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_TRANSFORMED_GRAPH)} {
         ?s a ${sparqlEscapeUri(type)}.
       }
       FILTER NOT EXISTS {

--- a/self-healing/transform-ldes-data-to-entities.ts
+++ b/self-healing/transform-ldes-data-to-entities.ts
@@ -1,8 +1,7 @@
 import { querySudo, updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri } from "mu";
 
-import { HEALING_DUMP_GRAPH, HEALING_TRANSFORMED_GRAPH } from "../environment";
-import { DIRECT_DB_ENDPOINT } from "../environment";
+import ENV from "../environment";
 
 export async function transformLdesDataToEntities() {
   await transformRemainingEntities();
@@ -22,25 +21,25 @@ async function transformBatchOfRemainingEntities() {
     PREFIX prov: <http://www.w3.org/ns/prov#>
 
     INSERT {
-      GRAPH ${sparqlEscapeUri(HEALING_TRANSFORMED_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_TRANSFORMED_GRAPH)} {
         ?entity ?p ?o.
       }
     }
     WHERE {
       { SELECT ?ldesEntity WHERE {
-          GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+          GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
             ?ldesStream tree:member ?ldesEntity.
             ?ldesEntity prov:generatedAtTime ?time.
           }
       } LIMIT 10000 }
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?ldesEntity dct:isVersionOf ?entity.
         ?ldesEntity ?p ?o.
       }
     }
   `,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
 
   // delete and insert split because of Virtuoso 22003 Error SR017: aref: Bad array subscript (zero-based) 4 for an arg of type ARRAY_OF_POINTER (193) and length 2.
@@ -51,21 +50,21 @@ async function transformBatchOfRemainingEntities() {
     PREFIX prov: <http://www.w3.org/ns/prov#>
 
     DELETE {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?ldesStream tree:member ?ldesEntity.
       }
     }
     WHERE {
-      GRAPH ${sparqlEscapeUri(HEALING_TRANSFORMED_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_TRANSFORMED_GRAPH)} {
         ?entity dct:isVersionOf ?entity.
       }
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?ldesStream tree:member ?ldesEntity.
         ?ldesEntity dct:isVersionOf ?entity.
       }
     }`,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
 }
 
@@ -77,14 +76,14 @@ async function hasRemainingEntities() {
     PREFIX prov: <http://www.w3.org/ns/prov#>
 
     SELECT (COUNT(DISTINCT(?ldesEntity)) as ?count) WHERE {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?ldesStream tree:member ?ldesEntity.
         ?ldesEntity dct:isVersionOf ?entity.
         ?ldesEntity prov:generatedAtTime ?time.
       }
     }`,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
   const count = parseInt(result.results.bindings[0].count.value);
   console.log(`Remaining entities: ${count}`);

--- a/self-healing/upload-entities-to-db.ts
+++ b/self-healing/upload-entities-to-db.ts
@@ -3,26 +3,21 @@ import { sparqlEscapeUri, sparqlEscapeString, sparqlEscape } from "mu";
 import ForkingStore from "forking-store";
 import { NamedNode } from "rdflib";
 
-import {
-  HEALING_BATCH_SIZE,
-  HEALING_DUMP_GRAPH,
-  HEALING_TRANSFORMED_GRAPH,
-} from "../environment";
-import { DIRECT_DB_ENDPOINT } from "../environment";
+import ENV from "../environment";
 
 export async function clearHealingTempGraphs(): Promise<void> {
   await updateSudo(
-    `DROP SILENT GRAPH <${HEALING_DUMP_GRAPH}>`,
+    `DROP SILENT GRAPH <${ENV.HEALING_DUMP_GRAPH}>`,
     {},
     {
-      sparqlEndpoint: DIRECT_DB_ENDPOINT,
+      sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT,
     }
   );
   await updateSudo(
-    `DROP SILENT GRAPH <${HEALING_TRANSFORMED_GRAPH}>`,
+    `DROP SILENT GRAPH <${ENV.HEALING_TRANSFORMED_GRAPH}>`,
     {},
     {
-      sparqlEndpoint: DIRECT_DB_ENDPOINT,
+      sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT,
     }
   );
 }
@@ -36,8 +31,8 @@ export async function insertLdesPageToDumpGraph(
   const statements = [...tripleStore.graph.statements];
   const tripleCount = statements.length;
   let batch: any[] = [];
-  for (let index = 0; index < tripleCount; index += HEALING_BATCH_SIZE) {
-    batch = statements.splice(0, HEALING_BATCH_SIZE);
+  for (let index = 0; index < tripleCount; index += ENV.HEALING_BATCH_SIZE) {
+    batch = statements.splice(0, ENV.HEALING_BATCH_SIZE);
     if (batch.length === 0) {
       continue;
     }
@@ -79,12 +74,12 @@ export async function deleteDuplicatesForValues(values?: string[]) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     INSERT {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?toDelete ext:willDelete true.
       }
     }
     WHERE {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         VALUES ?entity {
           ${[...valuesToDelete]
             .map((value) => sparqlEscapeUri(value))
@@ -103,7 +98,7 @@ export async function deleteDuplicatesForValues(values?: string[]) {
     }
   `,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
 
   await updateSudo(
@@ -113,19 +108,19 @@ export async function deleteDuplicatesForValues(values?: string[]) {
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     DELETE {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?ldesStream tree:member ?toDelete.
         ?toDelete ?p ?o.
       }
     }
     WHERE {
-      GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+      GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
         ?toDelete ext:willDelete true.
         ?toDelete ?p ?o.
       }
     }`,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
 
   valuesToDelete = new Set();
@@ -182,12 +177,12 @@ async function addTriplesToLDesDumpGraph(triples: string) {
   await updateSudo(
     `
       INSERT DATA {
-        GRAPH ${sparqlEscapeUri(HEALING_DUMP_GRAPH)} {
+        GRAPH ${sparqlEscapeUri(ENV.HEALING_DUMP_GRAPH)} {
           ${triples}
         }
       }
     `,
     {},
-    { sparqlEndpoint: DIRECT_DB_ENDPOINT, mayRetry: true }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT, mayRetry: true }
   );
 }

--- a/support.ts
+++ b/support.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { sparqlEscapeUri, sparqlEscape, sparqlEscapeBool } from "mu";
-import { LDES_FOLDER, LDES_FRAGMENTER } from "./environment";
+import ENV from "./environment";
 import { Changeset, Quad, Term } from "./types";
 import { addData, getConfigFromEnv } from "@lblod/ldes-producer";
 
@@ -54,7 +54,7 @@ export function toSparqlTriple(quad: Quad): string {
 
 export async function moveTriples(
   changesets: Changeset[],
-  stream = LDES_FOLDER
+  stream = ENV.LDES_FOLDER
 ) {
   let turtleBody = "";
   for (const { inserts } of changesets) {
@@ -76,6 +76,6 @@ export async function moveTriples(
     contentType: "text/turtle",
     folder: stream,
     body: turtleBody,
-    fragmenter: LDES_FRAGMENTER,
+    fragmenter: ENV.LDES_FRAGMENTER,
   });
 }

--- a/util/ttlFileAsContentType.ts
+++ b/util/ttlFileAsContentType.ts
@@ -5,7 +5,7 @@ import jsstream from "stream";
 import rdfParser from "rdf-parse";
 
 import rdfSerializer from "rdf-serialize";
-import { DATA_FOLDER } from "../environment";
+import ENV from "../environment";
 
 /**
  * Reads the triples in a file, assuming text/turtle.
@@ -21,7 +21,7 @@ export function ttlFileAsContentType(
 ): NodeJS.ReadableStream {
   const triplesStream = readTriplesStream(
     file,
-    domainName && domainName + path.relative(`${DATA_FOLDER}/`, file)
+    domainName && domainName + path.relative(`${ENV.DATA_FOLDER}/`, file)
   );
   return rdfSerializer.serialize(triplesStream, {
     contentType: contentType,

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -6,12 +6,7 @@ import fs from "fs";
 import { initialization } from "./config/initialization";
 import { v4 as uuid } from "uuid";
 import { querySudo } from "@lblod/mu-auth-sudo";
-import {
-  CRON_CHECKPOINT,
-  DATA_FOLDER,
-  DIRECT_DB_ENDPOINT,
-  LDES_BASE,
-} from "./environment";
+import ENV from "./environment";
 import { CronJob } from "cron";
 import { LDES } from "@lblod/ldes-producer";
 
@@ -52,7 +47,7 @@ function createTtlSparqlClient(turtle = true) {
       options.requestDefaults.headers["mu-auth-allowed-groups"] = allowedGroups;
   }
 
-  return new SparqlClient(DIRECT_DB_ENDPOINT, options);
+  return new SparqlClient(ENV.DIRECT_DB_ENDPOINT, options);
 }
 
 const ttlClient = createTtlSparqlClient();
@@ -137,7 +132,7 @@ async function countMatchesForType(stream, type) {
 
 function getCurrentFile(ldesStream: string, checkpoint?: string) {
   let highestNumber = 1;
-  let directory = `${DATA_FOLDER}/${ldesStream}`;
+  let directory = `${ENV.DATA_FOLDER}/${ldesStream}`;
   if (checkpoint) {
     directory = `${directory}/checkpoints/${checkpoint}`;
   }
@@ -211,7 +206,7 @@ async function startFile(
   checkpoint?: string,
 ) {
   console.log(`[${streamName}]  starting new file ${fileCount}`);
-  const streamUri = `<${LDES_BASE}${streamName}>`;
+  const streamUri = `<${ENV.LDES_BASE}${streamName}>`;
   const base = checkpoint ? `./checkpoints/${checkpoint}` : ".";
   const triplesToAdd = `
   ${streamUri} <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ${sparqlEscapeUri(LDES("EventStream").value)} .
@@ -342,8 +337,8 @@ export async function writeInitialState() {
   console.log("writing initial state");
 
   for (const ldesStream in initialization) {
-    if (!fs.existsSync(`${DATA_FOLDER}/${ldesStream}`)) {
-      fs.mkdirSync(`${DATA_FOLDER}/${ldesStream}`);
+    if (!fs.existsSync(`${ENV.DATA_FOLDER}/${ldesStream}`)) {
+      fs.mkdirSync(`${ENV.DATA_FOLDER}/${ldesStream}`);
     }
     await cleanupVersionedUris();
     // force new file twice so we get an empty first page that can easily be fetched a lot and later modified to point to shortcuts
@@ -368,7 +363,7 @@ function ensureCheckpointDir(ldesStream: string) {
     .split(":")
     .join("-")
     .split(".")[0];
-  const checkpointDir = `${DATA_FOLDER}/${ldesStream}/checkpoints/${checkpointName}`;
+  const checkpointDir = `${ENV.DATA_FOLDER}/${ldesStream}/checkpoints/${checkpointName}`;
   if (!fs.existsSync(checkpointDir)) {
     fs.mkdirSync(checkpointDir, { recursive: true });
   }
@@ -376,14 +371,14 @@ function ensureCheckpointDir(ldesStream: string) {
 }
 
 async function writeCheckpointRef(ldesStream: string, checkpointName: string) {
-  let directory = `${DATA_FOLDER}/${ldesStream}`;
+  let directory = `${ENV.DATA_FOLDER}/${ldesStream}`;
   const stream = fs.createWriteStream(`${directory}/checkpoints.ttl`, {
     flags: "a",
   });
   console.log(
     `[${ldesStream}]  writing checkpoint reference ${checkpointName}`,
   );
-  const streamUri = `<${LDES_BASE}${ldesStream}>`;
+  const streamUri = `<${ENV.LDES_BASE}${ldesStream}>`;
   const triplesToAdd = `
     ${streamUri} <http://mu.semte.ch/vocabularies/ext/ldesCheckpoint> <./checkpoints/${checkpointName}/1> .
     <./checkpoints/${checkpointName}/1> <http://purl.org/dc/terms/modified> "${new Date().toISOString()}"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n`;
@@ -439,9 +434,9 @@ const checkpointCron = async () => {
   isRunning = false;
 };
 
-export const cronjob = CRON_CHECKPOINT
+export const cronjob = ENV.CRON_CHECKPOINT
   ? CronJob.from({
-      cronTime: CRON_CHECKPOINT,
+      cronTime: ENV.CRON_CHECKPOINT,
       onTick: checkpointCron,
     })
   : null;


### PR DESCRIPTION
This PR adjusts the way environment variables are parsed. They are now parsed in a type-safe way using zod, and are parsed as one big `ENV` object.

If another library is more desired to do the parsing, I'm happy to adjust it.