### PR TITLE
Fix types

### DIFF
--- a/.woodpecker/.verify-pr.yml
+++ b/.woodpecker/.verify-pr.yml
@@ -1,0 +1,12 @@
+steps:
+  install:
+    image: node:20-alpine
+    commands:
+      - npm ci
+  lint:types:
+    image: node:20-alpine
+    depends_on: [install]
+    commands:
+      - npm run lint:types
+when:
+  - event: pull_request

--- a/app.ts
+++ b/app.ts
@@ -4,7 +4,7 @@ import type { Request, Response } from "express";
 import { app, errorHandler } from "mu";
 import dispatch from "./config/dispatch";
 
-import { Changeset } from "./types";
+import { DeltaChangeset } from "./types";
 import { writeInitialState } from "./writeInitialState";
 
 import { cronjob as autoHealing, manualTrigger } from "./self-healing/cron";
@@ -24,7 +24,7 @@ app.use(
 
 app.post("/publish", async function (req: Request, res: Response) {
   try {
-    const changeSets: Changeset[] = req.body;
+    const changeSets: DeltaChangeset[] = req.body;
     await dispatch(changeSets);
     res.send("Resource added to LDES");
   } catch (e) {

--- a/config/dispatch.ts
+++ b/config/dispatch.ts
@@ -1,7 +1,7 @@
 import { moveTriples } from "../support";
-import { Changeset } from "../types";
+import { DeltaChangeset } from "../types";
 
-export default async function dispatch(changesets: Changeset[]) {
+export default async function dispatch(changesets: DeltaChangeset[]) {
 	for (const changeset of changesets) {
 		await moveTriples([
 			{

--- a/config/healing.ts
+++ b/config/healing.ts
@@ -1,5 +1,21 @@
-export type HealingConfig = Awaited<ReturnType<typeof getHealingConfig>>;
-export const getHealingConfig = async () => {
+
+export type HealingConfig = {
+  [key: string]: {
+    graphFilter: string;
+    entities: {
+      [key: string]:
+        | {
+            healingPredicates: string[];
+            instanceFilter?: string;
+            healingFilter?: string;
+          }
+        | string[];
+    };
+    graphsToExclude?: string[];
+    graphTypesToExclude?: string[];
+  };
+};
+export const getHealingConfig: () => Promise<HealingConfig> = async () => {
   return {
     // this is the name of a stream, you can have multiple streams in the config,
     // the healing process will check them one by one sequentially

--- a/config/initialization.ts
+++ b/config/initialization.ts
@@ -7,9 +7,16 @@ const regularTypes = {
   "http://data.vlaanderen.be/ns/persoon#Geboorte": "abb",
   "http://schema.org/ContactPoint": "abb",
   "http://www.w3.org/ns/locn#Address": "abb",
-};
+} as const;
 
-export const initialization = {
+type Initialization = {
+  [key: string]: {
+    [key: string]: {
+      filter?: string;
+    }
+  }
+}
+export const initialization: Initialization = {
   public: {
     "http://data.vlaanderen.be/ns/mandaat#Mandataris": {
       filter: `
@@ -32,7 +39,7 @@ export const initialization = {
   },
 };
 
-Object.keys(regularTypes).forEach((type) => {
+(Object.keys(regularTypes) as (keyof typeof regularTypes)[]).forEach((type) => {
   const level = regularTypes[type];
   if (level === "public") {
     initialization.public[type] = {};

--- a/config/initialization.ts
+++ b/config/initialization.ts
@@ -13,6 +13,9 @@ type Initialization = {
   [key: string]: {
     [key: string]: {
       filter?: string;
+      graphFilter?: string;
+      extraConstruct?: string;
+      extraWhere?: string;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/express": "^4.17.17",
         "@types/node": "^20.19.37",
         "@types/node-fetch": "^2.6.2",
+        "@types/uuid": "^10.0.0",
         "release-it": "^15.6.0",
         "typescript": "^6.0.2",
         "zod": "^4.3.6"
@@ -1303,6 +1304,13 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@release-it-plugins/lerna-changelog": "^5.0.0",
         "@tsconfig/node20": "^20.1.9",
         "@types/express": "^4.17.17",
-        "@types/node": "^17.0.31",
+        "@types/node": "^20.19.37",
         "@types/node-fetch": "^2.6.2",
         "release-it": "^15.6.0",
         "typescript": "^6.0.2",
@@ -1208,9 +1208,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -1236,6 +1240,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,12 @@
       },
       "devDependencies": {
         "@release-it-plugins/lerna-changelog": "^5.0.0",
+        "@tsconfig/node20": "^20.1.9",
         "@types/express": "^4.17.17",
         "@types/node": "^17.0.31",
         "@types/node-fetch": "^2.6.2",
         "release-it": "^15.6.0",
+        "typescript": "^6.0.2",
         "zod": "^4.3.6"
       }
     },
@@ -1097,6 +1099,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
+      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -9354,6 +9363,20 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@graphy/content.ttl.read": "^4.3.4",
         "@graphy/content.ttl.write": "^4.3.4",
         "@lblod/ldes-producer": "0.9.0",
-        "@lblod/mu-auth-sudo": "^0.6.2",
+        "@lblod/mu-auth-sudo": "^1.1.0",
         "body-parser": "^1.20.0",
         "cron": "^3.1.7",
         "express-http-context": "~1.2.4",
@@ -656,12 +656,19 @@
       }
     },
     "node_modules/@lblod/mu-auth-sudo": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-0.6.2.tgz",
-      "integrity": "sha512-OsPRt+JCwlVmvCR2Y8j+8lhLp632mB0xNzBnQIcgCYdINyX0HW3Y+2G2roUO4tpOZjv0B85ijkoQ8j/WLSU6nw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lblod/mu-auth-sudo/-/mu-auth-sudo-1.1.0.tgz",
+      "integrity": "sha512-bJFVmyEZKHMk0dUs/1V6Qv9QNf9asIkliy7DN/TE6wxqDxcaUt5LyuRWzDGLvVJHwHkz+jK/eHp1krv0JCN0/A==",
+      "license": "MIT",
       "dependencies": {
-        "env-var": "^7.0.1",
-        "sparql-client-2": "git+https://github.com/erikap/node-sparql-client.git"
+        "digest-fetch": "^3.1.1",
+        "env-var": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "express-http-context": "~1.2.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1616,6 +1623,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2113,6 +2125,15 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -2558,6 +2579,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -3008,6 +3038,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/digest-fetch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-3.1.1.tgz",
+      "integrity": "sha512-sfMKKDctvDUTljFnqTBeDl/20vZtKKNZ3XQleht2j3Ky1xuQLuvE9lT+Fvp3EZxJHwAk6RXeEEL4DCmKDSd8xA==",
+      "license": "ISC",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "js-sha256": "^0.9.0",
+        "js-sha512": "^0.8.0",
+        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -4757,6 +4799,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5286,6 +5334,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
+    "node_modules/js-sha512": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5839,6 +5899,17 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdast-util-from-markdown": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "body-parser": "^1.20.0",
         "cron": "^3.1.7",
         "express-http-context": "~1.2.4",
-        "forking-store": "^2.2.0",
+        "forking-store": "^2.3.0",
         "node-fetch": "^2.6.7",
         "rdf-parse": "^2.0.0",
         "rdf-serialize": "^2.0.0",
@@ -3710,9 +3710,10 @@
       }
     },
     "node_modules/forking-store": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.2.0.tgz",
-      "integrity": "sha512-Gxodeyqx8JhC4F8aH8GW4oxuYQMyZtG8cuEIYy0csj9xOy8H7bVQ4DcQ2U31EPR/wqqbQT5EKeGj7p2ijMQhYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.3.0.tgz",
+      "integrity": "sha512-O47OntL9LGs2CoWTHNQHlB6J7vrUGhWrM1dJNaihoDIOh/5WvgBExp4PJPfkRB8t+yGPtef/tORQRlvG5qCw3Q==",
+      "license": "MIT",
       "dependencies": {
         "rdflib": "^2.2.19"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^20.19.37",
         "@types/node-fetch": "^2.6.2",
         "@types/uuid": "^10.0.0",
+        "concurrently": "^10.0.4",
         "release-it": "^15.6.0",
         "typescript": "^6.0.2"
       }
@@ -5635,6 +5636,185 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concurrently": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "5.6.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "10.2.2",
+        "tree-kill": "1.2.2",
+        "yargs": "18.0.0"
+      },
+      "bin": {
+        "conc": "dist/bin/index.js",
+        "concurrently": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/concurrently/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -6974,6 +7154,19 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -12387,6 +12580,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -12928,6 +13134,16 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@release-it-plugins/lerna-changelog": "^5.0.0",
     "@tsconfig/node20": "^20.1.9",
     "@types/express": "^4.17.17",
-    "@types/node": "^17.0.31",
+    "@types/node": "^20.19.37",
     "@types/node-fetch": "^2.6.2",
     "release-it": "^15.6.0",
     "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -19,14 +19,18 @@
     "sparql-client-2": "https://github.com/erikap/node-sparql-client.git"
   },
   "scripts": {
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:types": "tsc",
     "release": "release-it"
   },
   "devDependencies": {
     "@release-it-plugins/lerna-changelog": "^5.0.0",
+    "@tsconfig/node20": "^20.1.9",
     "@types/express": "^4.17.17",
     "@types/node": "^17.0.31",
     "@types/node-fetch": "^2.6.2",
     "release-it": "^15.6.0",
+    "typescript": "^6.0.2",
     "zod": "^4.3.6"
   },
   "release-it": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "body-parser": "^1.20.0",
     "cron": "^3.1.7",
     "express-http-context": "~1.2.4",
-    "forking-store": "^2.2.0",
+    "forking-store": "^2.3.0",
     "node-fetch": "^2.6.7",
     "rdf-parse": "^2.0.0",
     "rdf-serialize": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@graphy/content.ttl.read": "^4.3.4",
     "@graphy/content.ttl.write": "^4.3.4",
     "@lblod/ldes-producer": "0.9.0",
-    "@lblod/mu-auth-sudo": "^0.6.2",
+    "@lblod/mu-auth-sudo": "^1.1.0",
     "body-parser": "^1.20.0",
     "cron": "^3.1.7",
     "express-http-context": "~1.2.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^20.19.37",
     "@types/node-fetch": "^2.6.2",
+    "@types/uuid": "^10.0.0",
     "release-it": "^15.6.0",
     "typescript": "^6.0.2",
     "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "forking-store": "^2.3.0",
     "node-fetch": "^2.6.7",
     "rdf-parse": "^4.0.0",
-    "rdflib": "^2.2.35",
     "rdf-serialize": "^5.1.0",
+    "rdflib": "^2.2.35",
     "sparql-client-2": "https://github.com/erikap/node-sparql-client.git",
     "zod": "^4.3.6"
   },
   "scripts": {
-    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:types": "tsc",
     "release": "release-it"
   },
@@ -31,6 +31,7 @@
     "@types/node": "^20.19.37",
     "@types/node-fetch": "^2.6.2",
     "@types/uuid": "^10.0.0",
+    "concurrently": "^10.0.4",
     "release-it": "^15.6.0",
     "typescript": "^6.0.2"
   },

--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -82,8 +82,8 @@ async function fetchPage(stream: string, page: number): Promise<string | null> {
       nodeId: page,
     });
     return await text(response.stream);
-  } catch (e) {
-    if (e.status === 404) {
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'status' in e && e.status === 404) {
       console.log(
         `Page ${page} not found, assuming it's the last page of the stream`,
       );
@@ -107,15 +107,25 @@ async function determineFirstPageOrCheckpoint(
     const twoDaysAgo = new Date().getTime() - 1000 * 60 * 60 * 48;
     // only keep checkpoints that are older than two days so we are
     // reasonably sure the healing has taken effect in the main stream
-    const checkpoints = JSON.parse(fileString).filter((i) => {
+    const checkpoints = JSON.parse(fileString) as {
+      "@id": string;
+      "http://mu.semte.ch/vocabularies/ext/ldesCheckpoint"?: {
+        "@id": string;
+      }[];
+      "http://purl.org/dc/terms/modified"?: {
+        "@value": string;
+        "@type": string;
+      }[];
+    }[];
+    const filteredCheckpoints = checkpoints.filter((i) => {
       return (
         i[modified] && new Date(i[modified][0]["@value"]).getTime() < twoDaysAgo
       );
     });
-    checkpoints.sort((a: any, b: any) =>
+    filteredCheckpoints.sort((a: any, b: any) =>
       a[modified][0].value < b[modified][0].value ? 1 : -1,
     );
-    const checkpointName = checkpoints[0]["@id"].split("checkpoints/")[1];
+    const checkpointName = filteredCheckpoints[0]["@id"].split("checkpoints/")[1];
     const checkpointFolderName = checkpointName.split("/")[0];
     return { path: `${stream}/checkpoints/${checkpointFolderName}`, file: 1 };
   } catch (e) {

--- a/self-healing/cron.ts
+++ b/self-healing/cron.ts
@@ -32,14 +32,16 @@ const triggerHealing = async (startMessage: string) => {
   }
   isRunning = false;
 };
-const cronMethod = async () =>  triggerHealing(`
+const cronMethod = async () =>
+  triggerHealing(`
     *******************************************************************
     *** Pull LDES triggered by cron job at ${new Date().toISOString()} ***
-    *******************************************************************`)
-export const manualTrigger = async () =>  triggerHealing(`
+    *******************************************************************`);
+export const manualTrigger = async () =>
+  triggerHealing(`
     *******************************************************************
     *** Pull LDES triggered by manual trigger at ${new Date().toISOString()} ***
-    *******************************************************************`)
+    *******************************************************************`);
 
 async function healStream(stream: string, config: HealingConfig) {
   const startTime = performance.now();
@@ -47,7 +49,7 @@ async function healStream(stream: string, config: HealingConfig) {
   await clearHealingTempGraphs();
   await loadStreamIntoDumpGraph(stream);
   console.log(
-    `Loading LDES into dump graph took ${performance.now() - startTime} ms`
+    `Loading LDES into dump graph took ${performance.now() - startTime} ms`,
   );
   await transformLdesDataToEntities();
   await healEntities(stream, config);
@@ -56,9 +58,8 @@ async function healStream(stream: string, config: HealingConfig) {
 
 async function loadStreamIntoDumpGraph(stream: string): Promise<void> {
   let isLdesInsertedInDatabase = false;
-  let currentPage: PagePointer | null = await determineFirstPageOrCheckpoint(
-    stream
-  );
+  let currentPage: PagePointer | null =
+    await determineFirstPageOrCheckpoint(stream);
   while (!isLdesInsertedInDatabase && currentPage) {
     const turtleText = await fetchPage(currentPage.path, currentPage.file);
     if (turtleText) {
@@ -84,23 +85,23 @@ async function fetchPage(stream: string, page: number): Promise<string | null> {
   } catch (e) {
     if (e.status === 404) {
       console.log(
-        `Page ${page} not found, assuming it's the last page of the stream`
+        `Page ${page} not found, assuming it's the last page of the stream`,
       );
       return null;
     }
     throw new Error(
-      `Failed to fetch LDES page from stream ${stream}, error: ${e}`
+      `Failed to fetch LDES page from stream ${stream}, error: ${e}`,
     );
   }
 }
 async function determineFirstPageOrCheckpoint(
-  stream: string
+  stream: string,
 ): Promise<PagePointer> {
   try {
     console.log(`Fetching checkpoints for stream ${stream}`);
     const fileString = await ttlFileAsString(
       `${ENV.DATA_FOLDER}/${stream}/checkpoints.ttl`,
-      "application/ld+json"
+      "application/ld+json",
     );
     const modified = "http://purl.org/dc/terms/modified";
     const twoDaysAgo = new Date().getTime() - 1000 * 60 * 60 * 48;
@@ -112,7 +113,7 @@ async function determineFirstPageOrCheckpoint(
       );
     });
     checkpoints.sort((a: any, b: any) =>
-      a[modified][0].value < b[modified][0].value ? 1 : -1
+      a[modified][0].value < b[modified][0].value ? 1 : -1,
     );
     const checkpointName = checkpoints[0]["@id"].split("checkpoints/")[1];
     const checkpointFolderName = checkpointName.split("/")[0];
@@ -124,7 +125,7 @@ async function determineFirstPageOrCheckpoint(
 
 async function determineNextPage(
   stream: string,
-  currentPage: PagePointer
+  currentPage: PagePointer,
 ): Promise<PagePointer | null> {
   const pathWithoutEndSlash = currentPage.path.endsWith("/")
     ? currentPage.path.slice(0, -1)
@@ -139,15 +140,11 @@ async function determineNextPage(
     } LIMIT 1
   `;
   const result = await querySudo(query);
-  console.log(
-    `Next page query result: ${JSON.stringify(
-      result.results.bindings[0]?.page?.value
-    )}`
-  );
-  if (result.results.bindings.length === 0) {
+  if (!result || result.results.bindings.length === 0) {
     return null;
   }
   const page = result.results.bindings[0].page.value;
+  console.log(`Next page query result: ${JSON.stringify(page)}`);
   const safePartOfPageUrl = page.split(`/${stream}/`)[1];
   const splitSafePart = safePartOfPageUrl.split("/");
   const tail = splitSafePart[splitSafePart.length - 1];

--- a/self-healing/heal-ldes-data.ts
+++ b/self-healing/heal-ldes-data.ts
@@ -1,4 +1,4 @@
-import { querySudo, updateSudo } from "@lblod/mu-auth-sudo";
+import { querySudo, updateSudo, type Binding } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri, sparqlEscapeDateTime } from "mu";
 import dispatch from "../config/dispatch";
 import ENV from "../environment";
@@ -6,7 +6,7 @@ import { HealingConfig } from "../config/healing";
 
 export async function healEntities(
   stream: string,
-  config: HealingConfig
+  config: HealingConfig,
 ): Promise<void> {
   const rdfTypes = Object.keys(config[stream].entities);
   for (const type of rdfTypes) {
@@ -17,9 +17,9 @@ export async function healEntities(
 }
 
 async function triggerRecreate(
-  differences,
+  differences: Binding<string[]>[],
   stream: string,
-  config: HealingConfig
+  config: HealingConfig,
 ) {
   const uniqueSubjects = [
     ...new Set<string>(differences.map((difference) => difference.s.value)),
@@ -43,7 +43,7 @@ async function triggerRecreate(
   });
 
   console.log(
-    `Inserting ${inserts.length} triples: ${JSON.stringify(inserts)}`
+    `Inserting ${inserts.length} triples: ${JSON.stringify(inserts)}`,
   );
 
   await dispatch([
@@ -54,12 +54,12 @@ async function triggerRecreate(
   ]);
 }
 
-async function getSubjectTypes(subjects: string[], stream, config) {
+async function getSubjectTypes(subjects: string[], stream: string, config: HealingConfig) {
   let graphFilter = config[stream].graphFilter || "";
   const graphTypesToExclude = config[stream].graphTypesToExclude;
   const excludedGraphs = config[stream].graphsToExclude;
   let excludeGraphsFilter = "";
-  if (excludedGraphs?.length > 0) {
+  if (excludedGraphs && excludedGraphs.length > 0) {
     excludeGraphsFilter = excludedGraphs
       .map((graph: string) => sparqlEscapeUri(graph))
       .join(", ");
@@ -67,7 +67,7 @@ async function getSubjectTypes(subjects: string[], stream, config) {
   }
   let excludeGraphTypesFilter = "";
   let excludeGraphTypeValues = "";
-  if (graphTypesToExclude?.length > 0) {
+  if (graphTypesToExclude && graphTypesToExclude.length > 0) {
     excludeGraphTypeValues = graphTypesToExclude
       .map((type: string) => sparqlEscapeUri(type))
       .join("\n ");
@@ -94,8 +94,12 @@ async function getSubjectTypes(subjects: string[], stream, config) {
 
       ${graphFilter}
     }
-  `
+  `,
   );
+
+  if(!result){
+    return [];
+  }
 
   return result.results.bindings.map((binding) => {
     return {
@@ -108,15 +112,15 @@ async function getSubjectTypes(subjects: string[], stream, config) {
 async function getDifferences(
   type: string,
   stream: string,
-  config: HealingConfig
+  config: HealingConfig,
 ) {
-  const predicates =
-    config[stream].entities[type].healingPredicates ||
-    config[stream].entities[type];
-  const predicateValues = predicates
+  const entities = config[stream].entities[type];
+  const { healingPredicates, instanceFilter, healingFilter } = Array.isArray(entities)
+    ? { healingPredicates: entities, instanceFilter: "", healingFilter: "" }
+    : entities;
+  const predicateValues = healingPredicates
     .map((p: string) => sparqlEscapeUri(p))
     .join("\n");
-  const filter = config[stream].entities[type].instanceFilter || "";
 
   const excludedGraphs = config[stream].graphsToExclude || [];
   excludedGraphs.push(ENV.HEALING_DUMP_GRAPH);
@@ -130,22 +134,20 @@ async function getDifferences(
     .map((graph: string) => sparqlEscapeUri(graph))
     .join("\n");
 
-  const healingFilter = config[stream].entities[type].healingFilter || "";
-
   const missingLdesValues = await getMissingValuesLdes({
     type,
     predicateValues,
-    filter,
+    filter: instanceFilter ?? "",
     graphFilter,
     graphTypesToExclude,
     excludeGraphs,
-    healingFilter,
+    healingFilter: healingFilter ?? "",
   });
   // only looking for missing values on the ldes, excess values bring hard challenges like how did they even get here? should we purge them or is a tombstone enough? were they just not filtered out correctly?
   console.log(
     `Found ${missingLdesValues.length} missing values: ${JSON.stringify(
-      missingLdesValues
-    )}`
+      missingLdesValues,
+    )}`,
   );
   return missingLdesValues;
 }
@@ -231,27 +233,30 @@ async function getMissingValuesLdes(options: {
   const result = await querySudo(
     healingQuery,
     {},
-    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
+    { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT },
   );
+  if(!result){
+    return []
+  }
   return result.results.bindings.map((binding) => binding);
 }
 
 async function erectMissingTombstones(
   type: string,
   stream: string,
-  config: HealingConfig
+  config: HealingConfig,
 ) {
   const graphTypesToExclude = config[stream].graphTypesToExclude;
   let graphFilter = config[stream].graphFilter || "";
   const excludedGraphs = config[stream].graphsToExclude;
-  if (excludedGraphs?.length > 0) {
+  if (excludedGraphs && excludedGraphs.length > 0) {
     const toExclude = excludedGraphs
       .map((graph: string) => sparqlEscapeUri(graph))
       .join(", ");
     graphFilter += `FILTER(?g NOT IN (${toExclude}))`;
   }
   let excludeGraphTypeValues = "";
-  if (graphTypesToExclude?.length > 0) {
+  if (graphTypesToExclude && graphTypesToExclude.length > 0) {
     excludeGraphTypeValues = graphTypesToExclude
       .map((type: string) => sparqlEscapeUri(type))
       .join("\n ");
@@ -284,12 +289,12 @@ async function erectMissingTombstones(
       ${where}
     }
   `);
-  if (parseInt(count.results.bindings[0]?.count?.value || "0") < 1) {
+  if (parseInt(count!.results.bindings[0]?.count?.value || "0") < 1) {
     console.log(`No missing tombstones to erect for ${type}`);
     return;
   }
   console.log(
-    `Found ${count.results.bindings[0].count.value} missing tombstones for ${type}. Erecting...`
+    `Found ${count!.results.bindings[0].count.value} missing tombstones for ${type}. Erecting...`,
   );
 
   // we're putting the tombstones into the public graph. we don't know the graph they should have been put in

--- a/self-healing/transform-ldes-data-to-entities.ts
+++ b/self-healing/transform-ldes-data-to-entities.ts
@@ -85,6 +85,9 @@ async function hasRemainingEntities() {
     {},
     { sparqlEndpoint: ENV.DIRECT_DB_ENDPOINT }
   );
+  if(!result){
+    return false;
+  }
   const count = parseInt(result.results.bindings[0].count.value);
   console.log(`Remaining entities: ${count}`);
   return count > 0;

--- a/self-healing/upload-entities-to-db.ts
+++ b/self-healing/upload-entities-to-db.ts
@@ -1,9 +1,10 @@
 import { updateSudo } from "@lblod/mu-auth-sudo";
 import { sparqlEscapeUri, sparqlEscapeString, sparqlEscape } from "mu";
 import ForkingStore from "forking-store";
-import { NamedNode } from "rdflib";
+import { isLiteral, isNamedNode, NamedNode, type Statement } from "rdflib";
 
 import ENV from "../environment";
+import type { Term } from "rdflib/lib/tf-types";
 
 export async function clearHealingTempGraphs(): Promise<void> {
   await updateSudo(
@@ -126,7 +127,7 @@ export async function deleteDuplicatesForValues(values?: string[]) {
   valuesToDelete = new Set();
 }
 
-function mapStatementsToTriple(statements: any[]) {
+function mapStatementsToTriple(statements: Statement[]) {
   return statements.map((st) => {
     const object = formatValueForTermType(st.object);
 
@@ -136,7 +137,7 @@ function mapStatementsToTriple(statements: any[]) {
   });
 }
 
-const datatypeNames = {
+const datatypeNames: Record<string, string> = {
   "http://www.w3.org/2001/XMLSchema#dateTime": "dateTime",
   "http://www.w3.org/2001/XMLSchema#datetime": "dateTime",
   "http://www.w3.org/2001/XMLSchema#date": "date",
@@ -146,10 +147,10 @@ const datatypeNames = {
   "http://www.w3.org/2001/XMLSchema#boolean": "bool",
 };
 
-function formatValueForTermType(object) {
-  if (object.termType === "NamedNode") {
+function formatValueForTermType(object: Term) {
+  if (isNamedNode(object)) {
     return sparqlEscapeUri(object.value);
-  } else if (object.termType === "Literal") {
+  } else if (isLiteral(object)) {
     // we can't use the sparqlEscape function because it can for instance add timezones to our
     // datetimes and then they are not considered equal to sparql
     if (

--- a/support.ts
+++ b/support.ts
@@ -40,7 +40,7 @@ const sparqlEscapeObject = (bindingObject: Term): string => {
       (typeof bindingObject.value === 'string' && bindingObject.value?.toLowerCase() === "true");
     return sparqlEscapeBool(value);
   }
-  return bindingObject.type === "uri"
+  return (bindingObject.type === "uri" && typeof bindingObject.value === 'string')
     ? sparqlEscapeUri(bindingObject.value)
     : sparqlEscape(bindingObject.value, escapeType);
 };

--- a/support.ts
+++ b/support.ts
@@ -1,13 +1,13 @@
 // @ts-ignore
 import { sparqlEscapeUri, sparqlEscape, sparqlEscapeBool } from "mu";
 import ENV from "./environment";
-import { Changeset, Quad, Term } from "./types";
+import { DeltaChangeset, Quad, Term } from "./types";
 import { addData, getConfigFromEnv } from "@lblod/ldes-producer";
 
 const ldesProducerConfig = getConfigFromEnv();
 console.log("ldesProducerConfig", ldesProducerConfig);
 
-const datatypeNames = {
+const datatypeNames: Record<string, string> = {
   "http://www.w3.org/2001/XMLSchema#dateTime": "dateTime",
   "http://www.w3.org/2001/XMLSchema#date": "date",
   "http://www.w3.org/2001/XMLSchema#decimal": "decimal",
@@ -16,7 +16,6 @@ const datatypeNames = {
   "http://www.w3.org/2001/XMLSchema#boolean": "bool",
 };
 const sparqlEscapeObject = (bindingObject: Term): string => {
-
   // Might not be ideal: two ways of anotating language
   //   xml:lang  conforms to https://www.w3.org/TR/sparql11-results-json/
   //   lang      conforms to https://www.w3.org/TR/rdf-json/
@@ -38,7 +37,7 @@ const sparqlEscapeObject = (bindingObject: Term): string => {
     const value =
       bindingObject.value === true ||
       bindingObject.value === 1 ||
-      bindingObject.value?.toLowerCase() === "true";
+      (typeof bindingObject.value === 'string' && bindingObject.value?.toLowerCase() === "true");
     return sparqlEscapeBool(value);
   }
   return bindingObject.type === "uri"
@@ -53,7 +52,7 @@ export function toSparqlTriple(quad: Quad): string {
 }
 
 export async function moveTriples(
-  changesets: Changeset[],
+  changesets: DeltaChangeset[],
   stream = ENV.LDES_FOLDER
 ) {
   let turtleBody = "";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/types.ts
+++ b/types.ts
@@ -10,13 +10,17 @@ export type Term = {
   lang?: string;
 });
 
+
+
 export type Quad = {
   subject: Term;
   predicate: Term;
   object: Term;
 };
 
-export type Changeset = {
+export type DeltaChangeset = {
   inserts: Quad[];
   deletes: Quad[];
 };
+
+

--- a/types/mu.d.ts
+++ b/types/mu.d.ts
@@ -50,7 +50,7 @@ declare module 'mu' {
   export const sparqlEscapeInt: (value: number) => string;
   export const sparqlEscapeDecimal: (value: number) => string;
   export const sparqlEscapeFloat: (value: number) => string;
-  export const sparqlEscapeDateTime: (value: Date) => string;
+  export const sparqlEscapeDateTime: (value: Date | string) => string;
   export const sparqlEscapeBool: (value: boolean) => string;
   export const sparqlEscapeDate: (value: Date) => string;
   export const errorHandler: RequestHandler;

--- a/types/mu.d.ts
+++ b/types/mu.d.ts
@@ -1,0 +1,86 @@
+declare module 'mu' {
+  import { Express, RequestHandler } from 'express';
+
+  export type ObjectToBind = Record<string, unknown>;
+  export type BindingObject<Obj extends ObjectToBind = ObjectToBind> = {
+    [Prop in keyof Obj]: {
+      type: string;
+      value: string;
+    };
+  };
+
+  export type SparqlResponse<
+    ObjOrIsAsk extends ObjectToBind | true = ObjectToBind,
+  > = ObjOrIsAsk extends ObjectToBind
+    ? {
+        head: {
+          vars: string[];
+          link: [];
+        };
+        results: {
+          bindings: BindingObject<ObjOrIsAsk>[];
+        };
+      }
+    : {
+        head: unknown;
+        boolean: boolean;
+      };
+
+  export const app: Express;
+  /**
+   * The parameter ObjOrIsAsk should be the type of an object which the returned data will be passed
+   * in to. This allows TS to give us a return value that has the same keys mapped to Binding
+   * objects. If this is an ASK query, pass `true` instead as the return of this query will be
+   * different.
+   */
+  export interface UserOptions {
+    sudo?: boolean;
+    scope?: string;
+    endpoint?: string;
+  }
+  export const query: <ObjOrIsAsk extends ObjectToBind | true = ObjectToBind>(
+    query: string,
+    opts?: UserOptions,
+  ) => Promise<SparqlResponse<ObjOrIsAsk>>;
+  export const update: (query: string) => Promise<void>;
+  export const uuid: () => string;
+  export const sparqlEscape: (value: unknown, type: string) => string;
+  export const sparqlEscapeString: (value: string) => string;
+  export const sparqlEscapeUri: (value: string) => string;
+  export const sparqlEscapeInt: (value: number) => string;
+  export const sparqlEscapeDecimal: (value: number) => string;
+  export const sparqlEscapeFloat: (value: number) => string;
+  export const sparqlEscapeDateTime: (value: Date) => string;
+  export const sparqlEscapeBool: (value: boolean) => string;
+  export const sparqlEscapeDate: (value: Date) => string;
+  export const errorHandler: RequestHandler;
+  // this is a tagged template string function
+  export const sparql: (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => string;
+  export const SPARQL: (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ) => string;
+
+  const mu: {
+    app: typeof app;
+    query: typeof query;
+    update: typeof update;
+    uuid: typeof uuid;
+    sparqlEscape: typeof sparqlEscape;
+    sparqlEscapeString: typeof sparqlEscapeString;
+    sparqlEscapeUri: typeof sparqlEscapeUri;
+    sparqlEscapeInt: typeof sparqlEscapeInt;
+    sparqlEscapeDecimal: typeof sparqlEscapeDecimal;
+    sparqlEscapeFloat: typeof sparqlEscapeFloat;
+    sparqlEscapeDateTime: typeof sparqlEscapeDateTime;
+    sparqlEscapeBool: typeof sparqlEscapeBool;
+    sparqlEscapeDate: typeof sparqlEscapeDate;
+    errorHandler: typeof errorHandler;
+    sparql: typeof sparql;
+    SPARQL: typeof SPARQL;
+  };
+  export default mu;
+}

--- a/util/ttlFileAsContentType.ts
+++ b/util/ttlFileAsContentType.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error graphy doesn't have type definitions
 import ttl_read from "@graphy/content.ttl.read";
 import fs from "fs";
 import path from "path";

--- a/util/ttlFileAsContentType.ts
+++ b/util/ttlFileAsContentType.ts
@@ -2,7 +2,7 @@
 import ttl_read from "@graphy/content.ttl.read";
 import fs from "fs";
 import path from "path";
-import jsstream from "stream";
+import jsstream, { type Readable, type Stream } from "stream";
 import rdfParser from "rdf-parse";
 
 import rdfSerializer from "rdf-serialize";
@@ -42,7 +42,7 @@ export function ttlFileAsString(
   });
 }
 
-function readTriplesStream(file: string, baseIRI?: string): jsstream.Readable {
+function readTriplesStream(file: string, baseIRI?: string) {
   if (!fs.existsSync(file)) {
     throw Error(`File does not exist: ${file}`);
   }

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -1,5 +1,8 @@
+
+// @ts-expect-error sparql-client-2 doesn't have type declarations
 import sparqlClient from "sparql-client-2";
 const { SparqlClient } = sparqlClient;
+
 import { sparqlEscapeUri, sparqlEscapeDateTime } from "mu";
 import httpContext from "express-http-context";
 import fs from "fs";
@@ -114,7 +117,7 @@ async function executeDirectQuery(
   }
 }
 
-async function countMatchesForType(stream, type) {
+async function countMatchesForType(stream: string, type: string) {
   const filter = initialization[stream]?.[type]?.filter || "";
   const graphFilter = initialization[stream]?.[type]?.graphFilter || "";
   const res = await querySudo(
@@ -127,7 +130,7 @@ async function countMatchesForType(stream, type) {
       ${graphFilter}
     }`,
   );
-  return parseInt(res.results.bindings[0].count.value);
+  return parseInt(res!.results.bindings[0].count.value);
 }
 
 function getCurrentFile(ldesStream: string, checkpoint?: string) {


### PR DESCRIPTION
This PR fixes the types of this service, as well as introducing a CI step to validate the types.
**The following packages are updated**
- `forking-store` to the latest version (2.3.0) which contains type declarations
- `@lblod/mu-auth-sudo` to the latest version (1.1.0) which contains type declarations
- `@types/node` to version 20, matching the used node version

**The following packages are added:**
- `@tsconfig/node20`
- `@types/uuid`
- `typescript`

**This services contains depends on two packages which do not have type declarations:**
- `sparql-client-2`: I added a `@ts-expect-error` for now
- `graphy`: I added a `@ts-expect-error` for now

**Notes:**
- I did not introduce any logic changes
- Let me know if the inclusion of the CI step for type validation is too annoying


