### PR TITLE
Check `MAX_PAGE_SIZE_BYTES` in a more defensive way

### DIFF
--- a/.woodpecker/.fix.yml
+++ b/.woodpecker/.fix.yml
@@ -1,0 +1,13 @@
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: redpencil/ldes-delta-pusher
+      tags: "fix-${CI_COMMIT_BRANCH##fix/}"
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+when:
+  - event: push
+    branch: [fix/*]

--- a/app.ts
+++ b/app.ts
@@ -77,7 +77,7 @@ app.post("/manual-healing", async function (_req: Request, res: Response) {
 });
 
 new Promise(async (resolve) => {
-  if (process.env.WRITE_INITIAL_STATE === "true") {
+  if (ENV.WRITE_INITIAL_STATE) {
     await writeInitialState();
   }
 

--- a/app.ts
+++ b/app.ts
@@ -79,12 +79,14 @@ app.post("/manual-healing", async function (_req: Request, res: Response) {
 app.post("/manual-checkpoint", async function (_req: Request, res: Response) {
   try {
     await writeCheckpoint();
-  } catch (e){
+  } catch (e) {
     console.error(e);
     return res.status(500).send();
   }
-  res.status(200).send(`Checkpoint creation successful at ${new Date().toISOString()}`)
-})
+  res
+    .status(200)
+    .send(`Checkpoint creation successful at ${new Date().toISOString()}`);
+});
 
 new Promise(async (resolve) => {
   if (ENV.WRITE_INITIAL_STATE) {

--- a/app.ts
+++ b/app.ts
@@ -4,7 +4,7 @@ import { app, errorHandler } from "mu";
 import dispatch from "./config/dispatch";
 
 import { DeltaChangeset } from "./types";
-import { writeInitialState } from "./writeInitialState";
+import { writeCheckpoint, writeInitialState } from "./writeInitialState";
 
 import { cronjob as autoHealing, manualTrigger } from "./self-healing/cron";
 import ENV from "./environment";
@@ -75,6 +75,16 @@ app.post("/manual-healing", async function (_req: Request, res: Response) {
     .status(200)
     .send(`Healing succesfully completed at ${new Date().toISOString()}`);
 });
+
+app.post("/manual-checkpoint", async function (_req: Request, res: Response) {
+  try {
+    await writeCheckpoint();
+  } catch (e){
+    console.error(e);
+    return res.status(500).send();
+  }
+  res.status(200).send(`Checkpoint creation successful at ${new Date().toISOString()}`)
+})
 
 new Promise(async (resolve) => {
   if (ENV.WRITE_INITIAL_STATE) {

--- a/environment.ts
+++ b/environment.ts
@@ -4,8 +4,10 @@ const EnvSchema = z.object({
   LDES_FRAGMENTER: z.string().optional(),
   LDES_FOLDER: z.string(),
   DATA_FOLDER: z.string().default("/data"),
+
   AUTO_HEALING: z.stringbool().default(false),
   CRON_HEALING: z.string().default("0 * * * *" /* Every hour */),
+
   CRON_CHECKPOINT: z.string().optional(),
   HEALING_LIMIT: z.coerce.number().default(3000),
   HEALING_BATCH_SIZE: z.coerce.number().default(100),
@@ -17,6 +19,11 @@ const EnvSchema = z.object({
   LDES_BASE: z
     .string()
     .transform((base) => (!base.endsWith("/") ? base + "/" : base)),
+
+  WRITE_INITIAL_STATE: z.stringbool().default(false),
+  INITIAL_STATE_LIMIT: z.coerce.number().default(10000),
+  MAX_PAGE_SIZE_BYTES: z.coerce.number().default(10000000),
+  VIRTUOSO_DATE_WORKAROUND: z.stringbool().default(false),
 });
 
 const ENV = EnvSchema.parse(process.env);

--- a/self-healing/heal-ldes-data.ts
+++ b/self-healing/heal-ldes-data.ts
@@ -211,7 +211,7 @@ async function getMissingValuesLdes(options: {
     } LIMIT ${ENV.HEALING_LIMIT}
   `;
 
-  if (process.env.VIRTUOSO_DATE_WORKAROUND === "true") {
+  if (ENV.VIRTUOSO_DATE_WORKAROUND) {
     healingQuery = `
     SELECT DISTINCT ?s ?p ?o
     WHERE {

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -12,10 +12,8 @@ import ENV from "./environment";
 import { CronJob } from "cron";
 import { LDES } from "@lblod/ldes-producer";
 
-const limit = parseInt(process.env.INITIAL_STATE_LIMIT || "10000");
-const MAX_PAGE_SIZE_BYTES = parseInt(
-  process.env.MAX_PAGE_SIZE_BYTES || "10000000",
-);
+const limit = ENV.INITIAL_STATE_LIMIT;
+const MAX_PAGE_SIZE_BYTES = ENV.MAX_PAGE_SIZE_BYTES;
 
 let currentStream: fs.WriteStream;
 let currentStreamCharCount = 0;

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -225,6 +225,10 @@ async function writeToCurrentFile(
   checkpointName?: string,
 ) {
   const contentToWrite = contents + "\n";
+  if (contentToWrite.length > MAX_PAGE_SIZE_BYTES){
+    console.warn(`Writing batch of ${contentToWrite.length} bytes to page, which exceeds the MAX_PAGE_SIZE_BYTES limit (${MAX_PAGE_SIZE_BYTES} bytes).
+      Consider a smaller batch size (INITIAL_STATE_LIMIT) towards the future.`)
+  }
   if ( currentStreamCharCount > 0 && currentStreamCharCount + contentToWrite.length > MAX_PAGE_SIZE_BYTES) {
     console.log(
       `[${ldesStream}]  reached max page size ${MAX_PAGE_SIZE_BYTES}, starting new file`,

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -224,18 +224,15 @@ async function writeToCurrentFile(
   contents: string,
   checkpointName?: string,
 ) {
-  currentStream.write(contents + "\n");
-  currentStreamCharCount += contents.length;
-  if (currentStreamCharCount > MAX_PAGE_SIZE_BYTES) {
+  const contentToWrite = contents + "\n";
+  if ( currentStreamCharCount > 0 && currentStreamCharCount + contentToWrite.length > MAX_PAGE_SIZE_BYTES) {
     console.log(
-      `[${ldesStream}]  reached max page size ${currentStreamCharCount} > ${MAX_PAGE_SIZE_BYTES}, starting new file`,
+      `[${ldesStream}]  reached max page size ${MAX_PAGE_SIZE_BYTES}, starting new file`,
     );
     await forceNewFile(ldesStream, checkpointName);
-  } else {
-    console.log(
-      `[${ldesStream}]  current page size ${currentStreamCharCount} < ${MAX_PAGE_SIZE_BYTES}`,
-    );
   }
+  currentStream.write(contentToWrite);
+  currentStreamCharCount += contentToWrite.length;
 }
 
 async function writeInitialStateForStreamAndType(

--- a/writeInitialState.ts
+++ b/writeInitialState.ts
@@ -225,11 +225,14 @@ async function writeToCurrentFile(
   checkpointName?: string,
 ) {
   const contentToWrite = contents + "\n";
-  if (contentToWrite.length > MAX_PAGE_SIZE_BYTES){
+  if (contentToWrite.length > MAX_PAGE_SIZE_BYTES) {
     console.warn(`Writing batch of ${contentToWrite.length} bytes to page, which exceeds the MAX_PAGE_SIZE_BYTES limit (${MAX_PAGE_SIZE_BYTES} bytes).
-      Consider a smaller batch size (INITIAL_STATE_LIMIT) towards the future.`)
+      Consider a smaller batch size (INITIAL_STATE_LIMIT) towards the future.`);
   }
-  if ( currentStreamCharCount > 0 && currentStreamCharCount + contentToWrite.length > MAX_PAGE_SIZE_BYTES) {
+  if (
+    currentStreamCharCount > 0 &&
+    currentStreamCharCount + contentToWrite.length > MAX_PAGE_SIZE_BYTES
+  ) {
     console.log(
       `[${ldesStream}]  reached max page size ${MAX_PAGE_SIZE_BYTES}, starting new file`,
     );


### PR DESCRIPTION
### Overview
This PR includes two changes:
- (internal change): move remaining environment variables to `environment.ts`
- Adjustment to `writeToCurrentFile` to check `MAX_PAGE_SIZE_BYTES` more defensively (before writing instead of after)
