### PR TITLE
update rdf-parse package to version 4.0.0 to fix import issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "ldes-delta-pusher-service",
   "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
@@ -16,7 +16,7 @@
         "express-http-context": "~1.2.4",
         "forking-store": "^2.2.0",
         "node-fetch": "^2.6.7",
-        "rdf-parse": "^2.0.0",
+        "rdf-parse": "^4.0.0",
         "rdf-serialize": "^5.1.0",
         "rdflib": "^2.2.35",
         "sparql-client-2": "https://github.com/erikap/node-sparql-client.git",
@@ -81,6 +81,7 @@
       "engines": [
         "node >= 0.2.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3"
       }
@@ -95,18 +96,134 @@
       }
     },
     "node_modules/@comunica/actor-abstract-parse": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz",
-      "integrity": "sha512-0puCWF+y24EDOOAUUVVbC+tOf4UV+LzEbqi8T5v25jcVGCXyTqfra+bDywfrcv3adrVp18jLCJ46ycaH5xhy9Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.5.0.tgz",
+      "integrity": "sha512-THNdQsJ58HtkyeW9ghVyLrYEQfSPNfmVAJTDSqOxIujjCdimPbzS2LBXoDdw13GuxWWOATssbm1LwXDlX0xMIQ==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0",
-        "readable-stream": "^4.4.2"
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/@comunica/actor-abstract-parse/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -118,90 +235,762 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@comunica/actor-http-fetch": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.10.2.tgz",
-      "integrity": "sha512-siHGx0TMVNb2gXvOroq0B3JE6uuS+4s+MsDkntqdBNVigwVYqLpNSKEaL5is8pputFfohJfDQY06lAHbfDNEcw==",
+    "node_modules/@comunica/actor-abstract-parse/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^2.10.2",
-        "@comunica/context-entries": "^2.10.0",
-        "@comunica/mediatortype-time": "^2.10.0",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^4.0.0"
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
-    "node_modules/@comunica/actor-http-fetch/node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-4.5.0.tgz",
+      "integrity": "sha512-rhPBWOWe0tGDgwXbRgURwiGcbw1KY58oMByT7MVi5SLMpiK1Tjjb6KoMz5SOkZWsD1z6JY65J/VLxKFSj37ogQ==",
+      "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.7.0"
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-http-proxy": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.10.2.tgz",
-      "integrity": "sha512-3yUF8BCh4nwq8J6NRILEsyNrQNStkE9ggJ7hYwRfA1XcMgz1pANNaWJ2P2TEKH1jNinr23bL3JeuUZCm9Kz9dA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-4.5.0.tgz",
+      "integrity": "sha512-M5UQ+/IqXFNXLu9qSFNeeph/vaP349HQozqZzOY+HTO4TNWSIcB/XO6HgE3SC7r4G+KV+s9WbHwQO/8PxshBPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^2.10.2",
-        "@comunica/context-entries": "^2.10.0",
-        "@comunica/mediatortype-time": "^2.10.0",
-        "@comunica/types": "^2.10.0"
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/mediatortype-time": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.10.0.tgz",
-      "integrity": "sha512-zgImXKpc+BN1i6lQiN1Qhlb1HbKdMIeJMOys6qbzRIijdK8GkGGChwhQp7Cso3lY1Nf4K7M3jPLZeQXeED2w7g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-43PrAVCdHLcbJtPqZOVB9/4Zm5EDwIZrzUJhFPx7y30lzda1LmchL5aPrn5OPyrP3/AxK6U0Y9ISDZOBguOAEw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/bus-rdf-parse-html": "^2.10.0",
-        "@comunica/core": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "@rdfjs/types": "*",
-        "htmlparser2": "^9.0.0",
-        "readable-stream": "^4.4.2"
+        "htmlparser2": "^10.0.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.10.0.tgz",
-      "integrity": "sha512-JLfiDauq4SmpI6TDS4HaHzI6iJe1j8lSk5FRRYK6YVEu8eO28jPmxQJiOiwbQiYqsjsV7kON/WIZSoUELoI4Ig==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.5.0.tgz",
+      "integrity": "sha512-wxoXLS0nxV4ZqJEsx+zdZLjkRxZPFo+bXt+0fVEuDdBwL5WaJ6WPEL3fqbiH3QuaTu08k9klnsg2L1ncCeHhGg==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^2.10.0",
-        "@comunica/core": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "microdata-rdf-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz",
-      "integrity": "sha512-9K3iaws9+FGl50oZi53hqyzhwjNKZ3mIr2zg/TAJZoapKvc14cthH17zKSSJrqI/NgBStRmZhBBkXcwfu1CANw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.5.0.tgz",
+      "integrity": "sha512-o39tqHXAvKHnsa82Zm5FIbDRj+CSN46Nxj19TBSpCIsRlv5wJ9NpD6yxd7nGr1ovS5/5Ky7vDSdLcJ0MnJaNSQ==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^2.10.0",
-        "@comunica/core": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.10.0.tgz",
-      "integrity": "sha512-7XYqWchDquWnBLjG7rmmY+tdE81UZ8fPCU0Hn+vI39/MikNOpaiyr/ZYFqhogWFa9SkjmH0a7idVUzmjiwKRZQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.5.0.tgz",
+      "integrity": "sha512-eobWYbV4w7o/NK+6GMVkcaoGEQbTq2RmDDN63J1I/U0sTSQX0qvtLr0L4buOzGliIUttBbpsYfOc5YtJX6PP0g==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/bus-rdf-parse-html": "^2.10.0",
-        "@comunica/context-entries": "^2.10.0",
-        "@comunica/core": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/bus-rdf-parse-html": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "@rdfjs/types": "*",
-        "readable-stream": "^4.4.2",
+        "readable-stream": "^4.5.2",
         "relative-to-absolute-iri": "^1.0.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -211,12 +1000,142 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -228,59 +1147,418 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.10.2.tgz",
-      "integrity": "sha512-K4fvD0zMU22KkQCqIFVT5Oy2FREEZ9CAo9u6kOcsMxEvg9aHGIM6hkaXR8I+1JCx1mDuEj3zQ8joR4tQh8fYCw==",
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^2.10.2",
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/context-entries": "^2.10.0",
-        "@comunica/core": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.5.0.tgz",
+      "integrity": "sha512-QuYhMRNH7oc2RjpDCUWNoZiEkwgOGgQvT+GnCZz2pd2kHuTcH3iBo5FvDTLornSVO0RVchcpWGItN9zA2dCNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^4.5.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
         "jsonld-context-parser": "^2.2.2",
-        "jsonld-streaming-parser": "^3.0.1",
-        "stream-to-string": "^1.2.0"
+        "jsonld-streaming-parser": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz",
-      "integrity": "sha512-o1MAbwJxW4Br2WCZdhFoRmAiOP4mfogeQqJ4nqlsOkoMtQ45EvLHsotb3Kqhuk5V+vsTxyK5v/a4zylGtcU7VQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.5.0.tgz",
+      "integrity": "sha512-rERwWLr+fiFWuzWJe5Zoh0JvlaZn9DkvFGRl/5DntnDuwI91/U/p/atXBKfz/abpPAUs4hRGj5gkqmfdZg/bBQ==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/types": "^2.10.0",
-        "n3": "^1.17.0"
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "n3": "^1.26.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.10.0.tgz",
-      "integrity": "sha512-HoJN52shXY3cvYtsS0cpin9KXpW3L7g1leebyCRSqnlnHdJv5D6G0Ep8vyt2xhquKNbOQ7LnP5VhiDiqz73XDg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.5.0.tgz",
+      "integrity": "sha512-KDmXZ7w++eMO1HXaKwbkx6o5wKTtSMTCdhMGb/ewHinw4XVwesAy9nu/C5CAhi8LpCjdAxa7kf5POejBXUWd3Q==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
         "rdfxml-streaming-parser": "^2.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-shaclc": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.10.0.tgz",
-      "integrity": "sha512-i6tmuZuS+RtDiSXpQc3s/PxtCqwIguo4ANmVB20PK4VWgQgBwoPG7LlNcJ0xmuH/3Bv6C2Agn18PLF6dZX+fKw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.5.0.tgz",
+      "integrity": "sha512-YFYn9ml/eCfZhBTYeaYJ0Qk6HerBi0H4acZYppcMKdh/GPJklzW9LOLlEfEzYstrqwPIKZzqgoBg5yvVgbmXpA==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/types": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.8.1",
-        "readable-stream": "^4.4.2",
-        "shaclc-parse": "^1.4.0",
-        "stream-to-string": "^1.2.0"
+        "asynciterator": "^3.9.0",
+        "readable-stream": "^4.5.2",
+        "shaclc-parse": "^1.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -292,14 +1570,145 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz",
-      "integrity": "sha512-68r/6B/fEyA1/OYleVuaPq47J+g4xJcJijpdL1wEj7CqjV+Xa+sDWRpNCyLcD/e1Y/g9UQmLz0ZnSpR00PFddA==",
+    "node_modules/@comunica/actor-rdf-parse-shaclc/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.5.0.tgz",
+      "integrity": "sha512-1uQuq3xsokT0wWf9O6d+SyuNEvGX+bgSSGBCQF9YDjc2RygiZATUdThDmh4VDUYJzUCxHb3YM1XyJ+U2Si6xpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^4.5.0",
+        "@comunica/context-entries": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "rdfa-streaming-parser": "^2.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/actor-rdf-serialize-jsonld": {
@@ -543,15 +1952,149 @@
       }
     },
     "node_modules/@comunica/bus-http": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.10.2.tgz",
-      "integrity": "sha512-MAYRF6uEBAuJ9dCPW2Uyne7w3lNwXFXKfa14XuPG5DFTDpgo/Z2pWupPrBsA1eIWMNJ6WOG6QyEv4rllSIBqlg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-4.5.0.tgz",
+      "integrity": "sha512-wWyPNNOl6shDbtibdBl/pa9OIcoEMemNIo/J4tUViXxYXZ8i1h4FZ6PqaLtAls6O+pV71mR4SKJzKEUuiZiXPg==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0",
-        "@smessie/readable-web-to-node-stream": "^3.0.3",
+        "@comunica/core": "^4.5.0",
+        "@jeswr/stream-to-string": "^2.0.0",
         "is-stream": "^2.0.1",
-        "readable-stream-node-to-web": "^1.0.1",
-        "web-streams-ponyfill": "^1.4.2"
+        "readable-from-web": "^1.0.0",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/bus-http/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/bus-http/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/bus-init": {
@@ -579,23 +2122,305 @@
       }
     },
     "node_modules/@comunica/bus-rdf-parse": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.10.0.tgz",
-      "integrity": "sha512-EgCMZACfTG/+mayQpExWt0HoBT32BBVC1aS1lC43fXKBTxJ8kYrSrorVUuMACoh4dQVGTb+7j1j4K0hGNVzXGA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.5.0.tgz",
+      "integrity": "sha512-TnTS9F2GSbibuCd0Rep20C9WXU0KH0iWl2S2xycefMFrZK7noA8LeT/AHNshQlMPKejKxWME+jNsvcXgC++8zw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.10.0",
-        "@comunica/actor-abstract-parse": "^2.10.0",
-        "@comunica/core": "^2.10.0",
+        "@comunica/actor-abstract-mediatyped": "^4.5.0",
+        "@comunica/actor-abstract-parse": "^4.5.0",
+        "@comunica/core": "^4.5.0",
         "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
       }
     },
     "node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.10.0.tgz",
-      "integrity": "sha512-RZliz4TtKP63QggoohGuIkGb6lq0BoYJ4aztKtGldWtPAVP/pdEvlDpiZWLB/j19g7S2aDLNY/lJtZ5efM1tHQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-4.5.0.tgz",
+      "integrity": "sha512-yKsPuCIOLF5TXqoXXo+utZehG2diTCBnNleXrOI8Utr4Qu5rAU4oQ5+FC0UByMu5hr+g/TGm2A+IHSVzFRCUfw==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0",
+        "@comunica/core": "^4.5.0",
         "@rdfjs/types": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.5.0.tgz",
+      "integrity": "sha512-KbLuhbTcfAQHJeLo3CDDdffCZdfA1qDu15XIdW+7P03UpUp9xMw4p1G0kYtoXwj9KzWguY704TUtpJVBO1GOnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/bus-rdf-serialize": {
@@ -673,15 +2498,149 @@
       "integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA=="
     },
     "node_modules/@comunica/context-entries": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.10.0.tgz",
-      "integrity": "sha512-lmCYCcXxW8C6ecFH2whZCt31NT1ejb0P/sbytK7f4ctyA06Q8iYFEcYE4eWOXMdpfkwkcnz31x9XL77OGeSC2Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-4.5.0.tgz",
+      "integrity": "sha512-mgeSYFBcpMKLq34COpy129LVHigGUgA1uEI66WXmk3mdmlAKRQNe9D/W2Q924w0FZZmIOpeLMo+s358tFsodow==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0",
-        "@comunica/types": "^2.10.0",
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0",
         "@rdfjs/types": "*",
         "jsonld-context-parser": "^2.2.2",
-        "sparqlalgebrajs": "^4.2.0"
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/context-entries/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/context-entries/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/context-entries/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/core": {
@@ -714,11 +2673,145 @@
       }
     },
     "node_modules/@comunica/mediator-number": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.10.0.tgz",
-      "integrity": "sha512-0T8D1HGTu5Sd8iKb2dBjc6VRc/U4A15TAN6m561ra9pFlP+w31kby0ZYP6WWBHBobbUsX1LCvnbRQaAC4uWwVw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-4.5.0.tgz",
+      "integrity": "sha512-fChc4gh+gtwPOS0F5eNeDuU4Kyb2fAuppN28d1/5s+OUr5v+1Wya7yZ1zbPHYxDMWZEpJBR06eX6djcI0gKlkQ==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0"
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/mediator-number/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/mediator-number/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediator-number/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/mediator-race": {
@@ -730,11 +2823,145 @@
       }
     },
     "node_modules/@comunica/mediatortype-time": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.10.0.tgz",
-      "integrity": "sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-4.5.0.tgz",
+      "integrity": "sha512-HND+om4L0VW3VcQrLHHE4+7Nsg7soC98i7g7UqqzDkJ4fix2FnJs0i9WH4RP+oLcx+bPhBSl5mG1m44A6sV19g==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^2.10.0"
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
       }
     },
     "node_modules/@comunica/types": {
@@ -938,6 +3165,15 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/@jeswr/stream-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jeswr/stream-to-string/-/stream-to-string-2.0.0.tgz",
+      "integrity": "sha512-VmoW6xYRjVzdMr2njBObVSlUc5KCJT+gyuuH+tea9ZLE59XhgfLNc8ufN5Md38STxCyAJUDUVcCBfaOo11BfuA==",
+      "license": "MIT",
+      "dependencies": {
+        "event-emitter-promisify": "^1.1.0"
+      }
+    },
     "node_modules/@lblod/ldes-producer": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@lblod/ldes-producer/-/ldes-producer-0.9.0.tgz",
@@ -955,6 +3191,158 @@
         "rdf-serialize": "^2.0.0",
         "rdf-store-stream": "^1.3.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-abstract-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz",
+      "integrity": "sha512-0puCWF+y24EDOOAUUVVbC+tOf4UV+LzEbqi8T5v25jcVGCXyTqfra+bDywfrcv3adrVp18jLCJ46ycaH5xhy9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-http-fetch": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.10.2.tgz",
+      "integrity": "sha512-siHGx0TMVNb2gXvOroq0B3JE6uuS+4s+MsDkntqdBNVigwVYqLpNSKEaL5is8pputFfohJfDQY06lAHbfDNEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-http-proxy": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.10.2.tgz",
+      "integrity": "sha512-3yUF8BCh4nwq8J6NRILEsyNrQNStkE9ggJ7hYwRfA1XcMgz1pANNaWJ2P2TEKH1jNinr23bL3JeuUZCm9Kz9dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-zgImXKpc+BN1i6lQiN1Qhlb1HbKdMIeJMOys6qbzRIijdK8GkGGChwhQp7Cso3lY1Nf4K7M3jPLZeQXeED2w7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^9.0.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.10.0.tgz",
+      "integrity": "sha512-JLfiDauq4SmpI6TDS4HaHzI6iJe1j8lSk5FRRYK6YVEu8eO28jPmxQJiOiwbQiYqsjsV7kON/WIZSoUELoI4Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz",
+      "integrity": "sha512-9K3iaws9+FGl50oZi53hqyzhwjNKZ3mIr2zg/TAJZoapKvc14cthH17zKSSJrqI/NgBStRmZhBBkXcwfu1CANw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.10.0.tgz",
+      "integrity": "sha512-7XYqWchDquWnBLjG7rmmY+tdE81UZ8fPCU0Hn+vI39/MikNOpaiyr/ZYFqhogWFa9SkjmH0a7idVUzmjiwKRZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.10.2.tgz",
+      "integrity": "sha512-K4fvD0zMU22KkQCqIFVT5Oy2FREEZ9CAo9u6kOcsMxEvg9aHGIM6hkaXR8I+1JCx1mDuEj3zQ8joR4tQh8fYCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^3.0.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz",
+      "integrity": "sha512-o1MAbwJxW4Br2WCZdhFoRmAiOP4mfogeQqJ4nqlsOkoMtQ45EvLHsotb3Kqhuk5V+vsTxyK5v/a4zylGtcU7VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.10.0.tgz",
+      "integrity": "sha512-HoJN52shXY3cvYtsS0cpin9KXpW3L7g1leebyCRSqnlnHdJv5D6G0Ep8vyt2xhquKNbOQ7LnP5VhiDiqz73XDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.10.0.tgz",
+      "integrity": "sha512-i6tmuZuS+RtDiSXpQc3s/PxtCqwIguo4ANmVB20PK4VWgQgBwoPG7LlNcJ0xmuH/3Bv6C2Agn18PLF6dZX+fKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "readable-stream": "^4.4.2",
+        "shaclc-parse": "^1.4.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz",
+      "integrity": "sha512-68r/6B/fEyA1/OYleVuaPq47J+g4xJcJijpdL1wEj7CqjV+Xa+sDWRpNCyLcD/e1Y/g9UQmLz0ZnSpR00PFddA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
       }
     },
     "node_modules/@lblod/ldes-producer/node_modules/@comunica/actor-rdf-serialize-jsonld": {
@@ -992,6 +3380,41 @@
         "shaclc-write": "^1.4.2"
       }
     },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/bus-http": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.10.2.tgz",
+      "integrity": "sha512-MAYRF6uEBAuJ9dCPW2Uyne7w3lNwXFXKfa14XuPG5DFTDpgo/Z2pWupPrBsA1eIWMNJ6WOG6QyEv4rllSIBqlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@smessie/readable-web-to-node-stream": "^3.0.3",
+        "is-stream": "^2.0.1",
+        "readable-stream-node-to-web": "^1.0.1",
+        "web-streams-ponyfill": "^1.4.2"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.10.0.tgz",
+      "integrity": "sha512-EgCMZACfTG/+mayQpExWt0HoBT32BBVC1aS1lC43fXKBTxJ8kYrSrorVUuMACoh4dQVGTb+7j1j4K0hGNVzXGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/actor-abstract-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-RZliz4TtKP63QggoohGuIkGb6lq0BoYJ4aztKtGldWtPAVP/pdEvlDpiZWLB/j19g7S2aDLNY/lJtZ5efM1tHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
     "node_modules/@lblod/ldes-producer/node_modules/@comunica/bus-rdf-serialize": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.10.0.tgz",
@@ -1003,12 +3426,133 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/context-entries": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.10.0.tgz",
+      "integrity": "sha512-lmCYCcXxW8C6ecFH2whZCt31NT1ejb0P/sbytK7f4ctyA06Q8iYFEcYE4eWOXMdpfkwkcnz31x9XL77OGeSC2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/mediator-number": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.10.0.tgz",
+      "integrity": "sha512-0T8D1HGTu5Sd8iKb2dBjc6VRc/U4A15TAN6m561ra9pFlP+w31kby0ZYP6WWBHBobbUsX1LCvnbRQaAC4uWwVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/@comunica/mediatortype-time": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.10.0.tgz",
+      "integrity": "sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
     "node_modules/@lblod/ldes-producer/node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/jsonld-streaming-parser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.4.0.tgz",
+      "integrity": "sha512-897CloyQgQidfkB04dLM5XaAXVX/cN9A2hvgHJo4y4jRhIpvg3KLMBBfcrswepV2N3T8c/Rp2JeFdWfVsbVZ7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.4.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/@lblod/ldes-producer/node_modules/rdf-parse": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.3.tgz",
+      "integrity": "sha512-N5XEHm+ajFzwo/vVNzB4tDtvqMwBosbVJmZl5DlzplQM9ejlJBlN/43i0ImAb/NMtJJgQPC3jYnkCKGA7wdo/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.3.0",
+        "stream-to-string": "^1.2.0"
       }
     },
     "node_modules/@lblod/ldes-producer/node_modules/rdf-serialize": {
@@ -1421,6 +3965,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
       "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -1444,6 +3989,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@smessie/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.3.tgz",
       "integrity": "sha512-8FFE7psRtRWQT31/duqbmgnSf2++QLR2YH9kj5iwsHhnoqSvHdOY3SAN5e7dhc+60p2cNk7rv3HYOiXOapTEXQ==",
+      "license": "MIT",
       "dependencies": {
         "process": "^0.11.10",
         "readable-stream": "^4.5.1"
@@ -1460,6 +4006,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -3603,6 +6150,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -3610,6 +6158,18 @@
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -3621,12 +6181,14 @@
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -3641,6 +6203,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -3734,9 +6297,10 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -3999,6 +6563,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-emitter-promisify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/event-emitter-promisify/-/event-emitter-promisify-1.1.0.tgz",
+      "integrity": "sha512-uyHG8gjwYGDlKoo0Txtx/u1HI1ubj0FK0rVqI4O0s1EymQm4iAEMbrS5B+XFlSaS8SZ3xzoKX+YHRZk8Nk/bXg==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -4744,9 +7314,9 @@
       "dev": true
     },
     "node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4754,11 +7324,12 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -5952,26 +8523,69 @@
       }
     },
     "node_modules/jsonld-streaming-parser": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.4.0.tgz",
-      "integrity": "sha512-897CloyQgQidfkB04dLM5XaAXVX/cN9A2hvgHJo4y4jRhIpvg3KLMBBfcrswepV2N3T8c/Rp2JeFdWfVsbVZ7g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
+      "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
+      "license": "MIT",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
         "@types/http-link-header": "^1.0.1",
-        "@types/readable-stream": "^2.3.13",
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.4.0",
+        "jsonld-context-parser": "^3.0.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/jsonld-context-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz",
+      "integrity": "sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/jsonld-streaming-parser/node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -6491,12 +9105,25 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
       "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
         "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.1.0",
         "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
@@ -6510,6 +9137,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -6521,6 +9149,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -7202,9 +9831,10 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.25.2.tgz",
-      "integrity": "sha512-ZBPnAgOw4sze/hnyoydNA5Ts9wbwiG+BXssTkdBKD6IkQZcg1IfQdo5AMU9JhsIu/RGtRD1QD0gphEhk/6ZnWA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "readable-stream": "^4.0.0"
@@ -8192,34 +10822,228 @@
       }
     },
     "node_modules/rdf-parse": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.3.tgz",
-      "integrity": "sha512-N5XEHm+ajFzwo/vVNzB4tDtvqMwBosbVJmZl5DlzplQM9ejlJBlN/43i0ImAb/NMtJJgQPC3jYnkCKGA7wdo/w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-4.0.0.tgz",
+      "integrity": "sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==",
+      "license": "MIT",
       "dependencies": {
-        "@comunica/actor-http-fetch": "^2.0.1",
-        "@comunica/actor-http-proxy": "^2.0.1",
-        "@comunica/actor-rdf-parse-html": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
-        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
-        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
-        "@comunica/actor-rdf-parse-n3": "^2.0.1",
-        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
-        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
-        "@comunica/bus-http": "^2.0.1",
-        "@comunica/bus-init": "^2.0.1",
-        "@comunica/bus-rdf-parse": "^2.0.1",
-        "@comunica/bus-rdf-parse-html": "^2.0.1",
-        "@comunica/config-query-sparql": "^2.0.1",
-        "@comunica/core": "^2.0.1",
-        "@comunica/mediator-combine-pipeline": "^2.0.1",
-        "@comunica/mediator-combine-union": "^2.0.1",
-        "@comunica/mediator-number": "^2.0.1",
-        "@comunica/mediator-race": "^2.0.1",
+        "@comunica/actor-http-fetch": "^4.0.1",
+        "@comunica/actor-http-proxy": "^4.0.1",
+        "@comunica/actor-rdf-parse-html": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^4.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^4.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^4.0.1",
+        "@comunica/actor-rdf-parse-n3": "^4.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^4.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^4.0.1",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^4.0.1",
+        "@comunica/bus-http": "^4.0.1",
+        "@comunica/bus-init": "^4.0.1",
+        "@comunica/bus-rdf-parse": "^4.0.1",
+        "@comunica/bus-rdf-parse-html": "^4.0.1",
+        "@comunica/config-query-sparql": "^4.0.1",
+        "@comunica/context-entries": "^4.0.1",
+        "@comunica/core": "^4.0.1",
+        "@comunica/mediator-combine-pipeline": "^4.0.1",
+        "@comunica/mediator-combine-union": "^4.0.1",
+        "@comunica/mediator-number": "^4.0.1",
+        "@comunica/mediator-race": "^4.0.1",
         "@rdfjs/types": "*",
-        "readable-stream": "^4.3.0",
-        "stream-to-string": "^1.2.0"
+        "rdf-data-factory": "^1.1.2",
+        "readable-stream": "^4.5.2",
+        "stream-to-string": "^1.2.1"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/bus-init": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-4.5.0.tgz",
+      "integrity": "sha512-9TYFLjirHDt7HPXj3eQW9KX3x5T3mZ1G/EKadL1gQxo0FAqs3y8TdicepCLhk3HY/egidlyv9WQYAPvJ+WAmAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "readable-stream": "^4.5.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/config-query-sparql": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-4.4.0.tgz",
+      "integrity": "sha512-ZVK6eqpYLNa3MRLOWjRaudgfSdraJH/oZIkc5S2doJI2ZmnHROqQUtjPs13kwkI3hGZ6MVBtLm55oz+tKj2lKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/core": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-4.5.0.tgz",
+      "integrity": "sha512-UFHBboFaY0eESH0H8qJRIRuRfda2QduS886l2sRum/V4qhzJkMpf3zdOoZoBbRDU24PBmliWysi9TEsaPsyRwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/types": "^4.5.0",
+        "immutable": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.5.0.tgz",
+      "integrity": "sha512-Z4uLxugl+Ls8oAwD0dAIQg+i1rkiXbpiFLhgv5h6nksnz9q6Nv14xItm6baivxAJ9p8XVHCOwPxW46YJBtWIoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0",
+        "@comunica/types": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-combine-union": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-4.5.0.tgz",
+      "integrity": "sha512-aCoO3CiANssR8PEjad2aNuCcfhKdUFZWplTWq77cVUMVc4nsUWNleeEvN6kfOx51qdT8lFpH3b8X+S7bT8CABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-race": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-4.5.0.tgz",
+      "integrity": "sha512-eAWjQolFMOxKoKuUMmcQzxwf/ZL9ooT0/OUWv1vbVfHIQb/eqDs/h8wDqwXMgEiK5dIF9ZQYaRL2vEaLq+U3Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/core": "^4.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/types": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-XhnkspVgYilchErpSAELHRA7B4wRszDdvCkhbd52vjLrThzGUDfDoGx+56y4AeziWkxQLNug8AZbo/Q6J2vCzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.9.0",
+        "lru-cache": "^10.0.1",
+        "sparqlalgebrajs": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@rdfjs/types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
+    },
+    "node_modules/rdf-parse/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/rdf-parse/node_modules/rdf-isomorphic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-2.0.1.tgz",
+      "integrity": "sha512-8pfA3PeDs1sVrZ2R3dCR4KRM69m3pQGhzviNQq5Az/+Zch4I+fKstjGxCZ5ADAFPsm9zxHk8zMEQ/BFcqlnLKw==",
+      "license": "MIT",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/rdf-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-2.0.1.tgz",
+      "integrity": "sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/rdf-string/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/rdf-terms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-2.0.0.tgz",
+      "integrity": "sha512-9O+ifVcvY4ZktOr+uXKswoOV6airAsIKeqCr+C47kFZBB8X+NyPSqDRGgI6X+je8It6z2e9jZhWwjJiEZ8Yn5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rdf-data-factory": "^2.0.0",
+        "rdf-string": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/rdf-terms/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdf-parse/node_modules/readable-stream": {
@@ -8235,6 +11059,38 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/sparqlalgebrajs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-5.0.2.tgz",
+      "integrity": "sha512-Xz7byRqWqCMkbM+3ogGmKO/wsezQKQQNleoggP03sCTTFfCh/ZlN5CGt+HkrOenDSktZ93jpKFbbaIRjLOYtWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^2.0.1",
+        "rdf-isomorphic": "^2.0.0",
+        "rdf-string": "^2.0.0",
+        "rdf-terms": "^2.0.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/sparqlalgebrajs/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/rdf-serialize": {
@@ -8466,12 +11322,25 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
       "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
         "htmlparser2": "^8.0.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0",
         "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
@@ -8485,6 +11354,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -8496,6 +11366,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -8555,6 +11426,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
       "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
         "@rubensworks/saxes": "^6.0.1",
@@ -8570,6 +11442,42 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
       "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-from-web": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-from-web/-/readable-from-web-1.0.0.tgz",
+      "integrity": "sha512-tei03fQhxqLEklpIvocFUR9hO42hiyYvdhwoNHAjJztPAQ8QS1NqF2AhLwzGxIGidPBJ4MCqB48wn7OAFCfhsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/readable-from-web/node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/readable-from-web/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -8597,7 +11505,8 @@
     "node_modules/readable-stream-node-to-web": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
-      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ=="
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==",
+      "license": "MIT"
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -9300,9 +12209,10 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shaclc-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.2.tgz",
-      "integrity": "sha512-wzYYacEPasBcQ1xYX1zYrdAVPnZTzTNoDLpkB4efBbDMahc9TdTdyqoqAbIOdcsXBUq7QxRtalzJ+3a0DEp5Og==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.3.tgz",
+      "integrity": "sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^2.0.0",
         "n3": "^1.16.3"
@@ -9312,6 +12222,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
       "integrity": "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -10258,7 +13169,8 @@
     "node_modules/validate-iri": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
-      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA=="
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
+      "license": "MIT"
     },
     "node_modules/validate-peer-dependencies": {
       "version": "2.2.0",
@@ -10335,7 +13247,8 @@
     "node_modules/web-streams-ponyfill": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
-      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
+      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -10626,7 +13539,8 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express-http-context": "~1.2.4",
     "forking-store": "^2.2.0",
     "node-fetch": "^2.6.7",
-    "rdf-parse": "^2.0.0",
+    "rdf-parse": "^4.0.0",
     "rdflib": "^2.2.35",
     "rdf-serialize": "^5.1.0",
     "sparql-client-2": "https://github.com/erikap/node-sparql-client.git",

--- a/util/ttlFileAsContentType.ts
+++ b/util/ttlFileAsContentType.ts
@@ -2,7 +2,7 @@ import ttl_read from "@graphy/content.ttl.read";
 import fs from "fs";
 import path from "path";
 import jsstream from "stream";
-import rdfParser from "rdf-parse";
+import { rdfParser } from "rdf-parse";
 
 import ENV from "../environment";
 import { rdfSerializer } from "rdf-serialize";
@@ -12,7 +12,7 @@ import { rdfSerializer } from "rdf-serialize";
  *
  * @param {string} file File path where the turtle file is stored.
  * @return {Stream} Stream containing all triples which were downloaded.
- */
+ */ 
 
 export function ttlFileAsContentType(
   file: string,


### PR DESCRIPTION
This PR updates the `rdf-parse` package from version 2.x to version 4.x. Version 3.0.0 of this package introduced an important fix regarding the import of the package in an es-module application.

This PR should fix the issue where it was not possible to call the `GET /checkpoints` endpoint due to an import error.